### PR TITLE
Feat/8 language chart

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
+    "chart.js": "^4.4.9",
     "next": "15.2.3",
     "pretendard": "^1.3.9",
     "react": "^19.0.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",
     "react-youtube": "^10.1.0"
   },

--- a/src/components/detail/LanguageChart.tsx
+++ b/src/components/detail/LanguageChart.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import {
+    Chart as ChartJS,
+    ArcElement,
+    Tooltip,
+    Legend,
+    ChartOptions,
+} from 'chart.js';
+import { Doughnut } from 'react-chartjs-2';
+import { useEffect, useMemo, useState } from 'react';
+
+ChartJS.register(ArcElement, Tooltip, Legend);
+
+const COLORS = [
+    '#FF6384', '#FF9F40', '#FFCD56', '#4BC0C0', '#36A2EB',
+];
+
+interface LanguageChartProps {
+    data: {
+        labels: string[];
+        values: number[];
+    };
+}
+
+export default function LanguageChart({ data }: LanguageChartProps) {
+    const [showLegend, setShowLegend] = useState(false);
+
+    useEffect(() => {
+        const updateLegend = () => {
+            setShowLegend(window.innerWidth >= 768);
+        };
+
+        updateLegend();
+        window.addEventListener('resize', updateLegend);
+        return () => window.removeEventListener('resize', updateLegend);
+    }, []);
+
+    const chartData = useMemo(() => ({
+        labels: data.labels,
+        datasets: [
+            {
+                label: '언어 비율',
+                data: data.values,
+                backgroundColor: data.values.map((_, i) => COLORS[i % COLORS.length]),
+                borderWidth: 1,
+            },
+        ],
+    }), [data]);
+
+    const options = useMemo<ChartOptions<'doughnut'>>(() => ({
+        responsive: true,
+        maintainAspectRatio: false,
+        layout: {
+            padding: {
+                right: 30,
+            },
+        },
+        plugins: {
+            legend: {
+                display: showLegend,
+                position: 'right',
+            },
+            tooltip: {
+                callbacks: {
+                    label: (context) => {
+                        const label = context.label || 'unknown';
+                        const value = context.raw || 0;
+                        return ` ${label} ${value}%`;
+                    },
+                },
+            },
+        },
+    }), [showLegend]);
+
+    return (
+        <div className="w-full max-w-sm min-w-[16rem] h-[300px] mx-auto p-3">
+            <Doughnut data={chartData} options={options} />
+        </div>
+    );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -241,6 +241,11 @@
   resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz#56f00962ff0c4e0eb93d34a047d29fa995e3e342"
   integrity sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==
 
+"@kurkle/color@^0.3.0":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.4.tgz#4d4ff677e1609214fc71c580125ddddd86abcabf"
+  integrity sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==
+
 "@napi-rs/wasm-runtime@^0.2.8", "@napi-rs/wasm-runtime@^0.2.9":
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.9.tgz#7278122cf94f3b36d8170a8eee7d85356dfa6a96"
@@ -917,6 +922,13 @@ chalk@^4.0.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+chart.js@^4.4.9:
+  version "4.4.9"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.4.9.tgz#602e2fc2462f0f7bb7b255eaa1b51f56a43a1362"
+  integrity sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==
+  dependencies:
+    "@kurkle/color" "^0.3.0"
 
 client-only@0.0.1:
   version "0.0.1"
@@ -2367,6 +2379,11 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+react-chartjs-2@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz#2d3286339a742bc7f77b5829c33ebab215f714cc"
+  integrity sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==
 
 react-dom@^19.0.0:
   version "19.1.0"


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #8 

---

### 🚀 어떤 기능을 구현했나요?
- `react-chartjs-2`를 사용하여 언어 비율을 시각화하는 도넛 차트 컴포넌트 구현
- 반응형 대응을 위해 md 이상일 때만 legend가 보이도록 설정

### 🔥 어떻게 해결했나요?
- Chart.js 및 react-chartjs-2 설치
- Chart.js 내부 옵션에 따라 legend 표시 조건부 설정
- `useEffect`로 창 크기에 따라 legend 표시 여부 업데이트
- `useMemo`로 chartData, options 메모이제이션 처리 (불필요한 차트 리렌더링 방지, 성능 최적화) 

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- legend 반응형 동작이 자연스럽게 동작하는지
- chart 크기나 스타일 관련 Tailwind 클래스가 적절한지

### 📚 참고 자료, 할 말
- Chart.js 공식 문서: https://www.chartjs.org/docs/latest/
