### PR TITLE
feat: 댓글 작성 시간대 차트 구현 (#10)

### DIFF
--- a/src/components/detail/CommentTimeChart.tsx
+++ b/src/components/detail/CommentTimeChart.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Title,
+    Tooltip,
+    TooltipItem,
+    Legend,
+    Filler,
+} from 'chart.js';
+import { Line } from 'react-chartjs-2';
+import { useMemo } from 'react';
+import {calculateYAxis} from "@/utils/calculateYAxis";
+
+ChartJS.register(
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Title,
+    Tooltip,
+    Legend,
+    Filler
+);
+
+interface CommentTimeData {
+    time: string;
+    count: number;
+}
+
+interface Props {
+    data: CommentTimeData[];
+}
+
+export default function CommentTimeChart({ data }: Props) {
+    const maxCount = Math.max(...data.map((d) => d.count));
+    const { stepSize, roundedMax } = calculateYAxis(maxCount);
+
+    const chartData = useMemo(() => {
+        return {
+            labels: data.map((d) => d.time),
+            datasets: [
+                {
+                    label: '댓글 수',
+                    data: data.map((d) => d.count),
+                    borderColor: 'rgba(255, 99, 132, 1)',
+                    backgroundColor: 'rgba(255, 99, 132, 0.3)',
+                    fill: true,
+                    tension: 0.4,
+                },
+            ],
+        };
+    }, [data]);
+
+    const options = {
+        maintainAspectRatio: false,
+        responsive: true,
+        plugins: {
+            legend: {
+                display: false,
+            },
+            tooltip: {
+                callbacks: {
+                    label: function (context: TooltipItem<'line'>) {
+                        const hour = context.label;
+                        const count = context.parsed.y;
+                        return ` ${hour}에 작성된 댓글: ${count.toLocaleString()}개`;
+                    }
+                }
+            }
+        },
+        scales: {
+            x: {
+                ticks: {
+                    maxRotation: 0,
+                    autoSkip: false,
+                },
+            },
+            y: {
+                beginAtZero: true,
+                max: roundedMax,
+                ticks: {
+                    stepSize,
+                    callback: (value: string | number) => `${value}개`,
+                }
+            },
+        },
+    };
+
+    return (
+        <div className="w-full max-w-sm min-w-[16rem] h-[250px] mx-auto p-1">
+            <Line data={chartData} options={options} />
+        </div>
+    );
+}

--- a/src/utils/calculateYAxis.ts
+++ b/src/utils/calculateYAxis.ts
@@ -1,0 +1,16 @@
+/**
+ * Y축 눈금 계산 유틸
+ * @param maxCount y축 최대 값
+ * @param targetSteps 원하는 눈금 개수 (기본 6)
+ * @returns { stepSize, roundedMax } 차트 옵션에 넣을 값
+ */
+export function calculateYAxis(maxCount: number, targetSteps = 6) {
+    if (maxCount <= 0) {
+        return { stepSize: 10, roundedMax: 50 };
+    }
+
+    const stepSize = Math.ceil(maxCount / targetSteps / 10) * 10;
+    const roundedMax = Math.ceil(maxCount / stepSize) * stepSize;
+
+    return { stepSize, roundedMax };
+}


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #10  

---

### 🚀 어떤 기능을 구현했나요?
- `Chart.js`와 `react-chartjs-2` 기반의 Line 컴포넌트 작성
- 전체 댓글 수 기반으로 y축 최대값과 눈금 간격 자동 계산
- `00시에 작성된 댓글: 123개` 형식으로 툴팁 표시
- 반응형 차트 크기 및 Tailwind 레이아웃 적용

### 🔥 어떻게 해결했나요?
- 댓글 수 최대값을 기준으로 `stepSize` 및 `roundedMax` 계산
- y축 계산 로직을 `utils/calculateYAxis.ts`로 분리

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- `calculateYAxis` 유틸의 계산 방식 (stepSize, roundedMax)
- 반응형 레이아웃이 적절한지 

### 📚 참고 자료, 할 말
- Chart.js 공식 문서 https://www.chartjs.org/docs/latest/