### PR TITLE
feat: 댓글 감정 분석 컴포넌트 구현 (#16)

### DIFF
--- a/src/components/detail/EmotionBar.tsx
+++ b/src/components/detail/EmotionBar.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+interface Type {
+    positive: number;
+    negative: number;
+    etc: number;
+}
+
+const COLORS = {
+    positive: {
+        text: 'text-blue-500',
+        bg: 'bg-blue-50',
+        hoverBg: 'hover:bg-blue-100/90',
+        label: '긍정',
+    },
+    negative: {
+        text: 'text-red-500',
+        bg: 'bg-red-50',
+        hoverBg: 'hover:bg-red-100/70',
+        label: '부정',
+    },
+    etc: {
+        text: 'text-gray-500',
+        bg: 'bg-gray-50',
+        hoverBg: 'hover:bg-gray-200/70',
+        label: '기타',
+    },
+} as const;
+
+const clampPercent = (value: number) => Math.max(0, Math.min(100, value));
+
+interface SegmentProps {
+    keyName: string;
+    label: string;
+    percent: number;
+    isHovered: boolean;
+    text: string;
+    bg: string;
+    hoverBg: string;
+    onClick: (label: string, percent: number) => void;
+    onHover: (key: string | null) => void;
+}
+
+function EmotionSegment({
+                            keyName,
+                            label,
+                            percent,
+                            isHovered,
+                            text,
+                            bg,
+                            hoverBg,
+                            onClick,
+                            onHover,
+                        }: SegmentProps) {
+    const displayWidth = isHovered && percent < 40 ? '50%' : `${percent}%`;
+    const shouldShowText = percent >= 10 || isHovered;
+
+    return (
+        <span
+            className={`
+        relative flex items-center min-h-[2.5rem] px-4 py-3
+        ${text} ${bg} ${hoverBg} cursor-pointer
+        ${isHovered ? 'font-semibold' : ''}
+        truncate whitespace-nowrap transition-all duration-300 ease-in-out
+      `}
+            style={{ width: displayWidth }}
+            onClick={() => onClick(label, percent)}
+            onMouseEnter={() => onHover(keyName)}
+            onMouseLeave={() => onHover(null)}
+        >
+      {shouldShowText ? `${label} ${percent}%` : ''}
+    </span>
+    );
+}
+
+export default function EmotionBar({ data }: { data: Type }) {
+    const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+    const onClick = useCallback((label: string, percent: number) => {
+        console.log(`${label}: ${percent}%`);
+    }, []);
+
+    return (
+        <div className="flex gap-2 items-center">
+            <div className="flex items-center w-full overflow-hidden rounded-full text-sm">
+                {Object.entries(data).map(([key, value]) => {
+                    const percent = clampPercent(value);
+                    const isHovered = hoveredKey === key;
+                    const { text, bg, hoverBg, label } = COLORS[key as keyof Type];
+
+                    return (
+                        <EmotionSegment
+                            key={key}
+                            keyName={key}
+                            label={label}
+                            percent={percent}
+                            isHovered={isHovered}
+                            text={text}
+                            bg={bg}
+                            hoverBg={hoverBg}
+                            onClick={onClick}
+                            onHover={setHoveredKey}
+                        />
+                    );
+                })}
+            </div>
+        </div>
+    );
+}

--- a/src/components/detail/index.tsx
+++ b/src/components/detail/index.tsx
@@ -6,6 +6,7 @@ import CommentTimeChart from "@components/detail/CommentTimeChart";
 import TagList from "@components/detail/TagList";
 import AISummary from "@components/detail/AISummary";
 import {mockVideoData} from "@mock/new-video-mock";
+import EmotionBar from "@components/detail/EmotionBar";
 
 export default function Detail() {
     // mock data
@@ -17,6 +18,7 @@ export default function Detail() {
     const commentTimes = mockData.video.analysis.commentTimes;
     const popularTimeTags = mockData.video.analysis.popularTimeTags;
     const keywordTags = mockData.video.analysis.keywordTags;
+    const emotionRatio = {positive: 61, negative: 34, etc: 5}
 
     return (
         <div className="flex flex-col w-full items-center max-w-[1000px] m-auto gap-10">
@@ -30,7 +32,8 @@ export default function Detail() {
                     <SectionLayout header="좋아요 Top 5">
                         <CommentList comments={commentsTop5}/>
                     </SectionLayout>
-                    <SectionLayout header="전체 댓글 확인하기">
+                    <SectionLayout header="전체 댓글 확인하기" type="search-comment">
+                        <EmotionBar data={emotionRatio}/>
                         <CommentList comments={commentsAll}/>
                     </SectionLayout>
                 </div>


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #16

---

### 🚀 어떤 기능을 구현했나요?
- `EmotionBar` 컴포넌트의 UI 구현 
  - 긍정, 부정, 기타를 각 퍼센트 값에 따라 막대 길이 동적으로 조정
  - 퍼센트가 작은 경우 텍스트를 숨기기 
  - 마우스 오버 시 텍스트 표시, 너비 확장, 색상 강조 효과 
- 각 감정 `span`을 `EmotionSegment` 컴포넌트로 분리하여 가독성 및 재사용성 향상

### 🔥 어떻게 해결했나요?
- `hoveredKey` 상태로 현재 `hover` 중인 항목 추적
- `percent`가 일정 기준 이하일 때 텍스트를 숨기고,  hover 시 `50%`로 확장 및 텍스트 노출, 강조 
- `EmotionSegment` 서브 컴포넌트를 도입해 EmotionBar의 map 내부 로직 정리
- COLORS 객체의 key 값을 기반으로 EmotionKey 타입을 추출해 타입 안정성 확보

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- `EmotionSegment` 분리 방식이 가독성과 확장성 측면에서 적절한지
- `hover` 시 너비 전환과 색상 강조가 자연스럽게 동작하는지
- `EmotionKey`, `EmotionData` 방식이 적절하고 유연한지

### 📚 참고 자료, 할 말
- [keyof types in TypeScript](https://www.typescriptlang.org/ko/docs/handbook/2/keyof-types.html)
- [typeof usage in TypeScript](https://www.typescriptlang.org/ko/docs/handbook/2/typeof-types.html)
- 이후 각 감정 클릭 시 해당되는 댓글 렌더링하는 과정 필요
