### PR TITLE
feat: 영상 및 댓글 정보 숫자/날짜 포맷팅 적용 (#38)

### DIFF
--- a/src/components/common/Comment/CommentItem.tsx
+++ b/src/components/common/Comment/CommentItem.tsx
@@ -1,5 +1,5 @@
 import { HandThumbUpIcon } from "@heroicons/react/24/solid";
-import { formatDate } from "@/utils/date";
+import {formatDate, formatNumber} from "@/utils/data-format";
 import { Comment } from "@/types/video";
 
 type Props = Comment & {
@@ -27,12 +27,12 @@ export default function CommentItem({
                     <div className="flex items-center gap-2">
                         <p className="text-sm font-semibold text-gray-800">{author}</p>
 
-                        <p className="text-sm text-gray-400">{formatDate(publishedAt)}</p>
+                        <p className="text-sm text-gray-400">{formatDate(publishedAt, true)}</p>
                         <span className={`text-xs px-2 py-[2px] rounded-full font-medium ${badge.color}`}>{badge.text}</span>
                     </div>
                     <div className="flex gap-1 items-center">
                         <HandThumbUpIcon className="w-4 h-4 text-gray-400"/>
-                        <p className="text-sm text-gray-500">{likeCount}</p>
+                        <p className="text-sm text-gray-500">{formatNumber(likeCount)}</p>
                     </div>
                 </div>
 

--- a/src/components/common/VideoSummary/VideoSummaryItem.tsx
+++ b/src/components/common/VideoSummary/VideoSummaryItem.tsx
@@ -8,6 +8,7 @@ import { FaceSmileIcon, HashtagIcon, SparklesIcon } from "@heroicons/react/24/ou
 import SummarySection from "@components/common/VideoSummary/SummarySection";
 import TagList from "@components/common/Tag/TagList";
 import type { VideoSummaryResponse } from "@/types/video-summary";
+import {formatDate, formatNumber} from "@/utils/data-format";
 
 type Props = {
     rank?: number;
@@ -35,13 +36,13 @@ export default function VideoSummaryItem({ rank, data }: Props) {
                 <div className="flex flex-col  flex-1 min-w-0">
                     <p className="font-semibold text-base line-clamp-2">{video.title}</p>
                     <p className="text-sm text-gray-500">
-                        {channel.title} | 구독자 {channel.subscriberCount.toLocaleString()}명
+                        {channel.title} | 구독자 {formatNumber(channel.subscriberCount)}명
                     </p>
                     <p className="text-sm text-gray-500">
-                        조회수 {video.viewCount.toLocaleString()} · 업로드일 {new Date(video.publishedAt).toLocaleDateString("ko-KR")}
+                        조회수 {formatNumber(video.viewCount)} · 업로드일 {formatDate(video.publishedAt)}
                     </p>
                     <p className="text-sm text-gray-400">
-                        좋아요 {video.likeCount.toLocaleString()}개 · 댓글 {video.commentCount.toLocaleString()}개
+                        좋아요 {formatNumber(video.likeCount)}개 · 댓글 {formatNumber(video.commentCount)}개
                     </p>
                 </div>
             </div>

--- a/src/components/detail/video-info/index.tsx
+++ b/src/components/detail/video-info/index.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { ChevronDownIcon } from "@heroicons/react/24/solid";
 import YouTubePlayer, { YouTubePlayerRef } from "./YoutubePlayer";
-import { formatDate } from "@/utils/date";
+import { formatDate } from "@/utils/data-format";
 import type { VideoResult } from "@/types/video";
 import { useAuth } from "@/contexts/AuthContext";
 import { createScrap, deleteScrap } from "@/service/videoService";

--- a/src/components/home/subscribed-channels/RecentVideo.tsx
+++ b/src/components/home/subscribed-channels/RecentVideo.tsx
@@ -2,7 +2,7 @@
 
 import ChannelAvatarList from "@components/home/subscribed-channels/ChannelAvatarList";
 import Thumbnail from "@components/home/Thumbnail";
-import { formatDate } from "@/utils/date";
+import {formatDate, formatNumber} from "@/utils/data-format";
 import { VideoSummaryResponse } from "@/types/video-summary";
 import SummarySection from "@components/common/VideoSummary/SummarySection";
 import {
@@ -35,7 +35,7 @@ const RecentVideo = ({ data }: { data: VideoSummaryResponse["data"] }) => {
                         <p className="text-base font-semibold line-clamp-2">{video.title}</p>
                         <div className="flex flex-wrap text-sm text-gray-500 gap-x-3">
                             <span>{channel.title}</span>
-                            <span>조회수 {video.viewCount.toLocaleString()}회</span>
+                            <span>조회수{formatNumber(video.viewCount)}회</span>
                             <span>{formatDate(video.publishedAt)}</span>
                         </div>
                     </div>

--- a/src/utils/data-format.ts
+++ b/src/utils/data-format.ts
@@ -1,0 +1,21 @@
+export function formatDate(dateString: string, withTime: boolean = false): string {
+    const date = new Date(dateString);
+    const yyyy = date.getFullYear();
+    const mm = String(date.getMonth() + 1).padStart(2, '0');
+    const dd = String(date.getDate()).padStart(2, '0');
+
+    if (withTime) {
+        const hh = String(date.getHours()).padStart(2, '0');
+        const mi = String(date.getMinutes()).padStart(2, '0');
+        return `${yyyy}.${mm}.${dd} ${hh}:${mi}`;
+    }
+
+    return `${yyyy}.${mm}.${dd}`;
+}
+
+export function formatNumber(num: number): string {
+    if (num >= 1_0000_0000) return (num / 1_0000_0000).toFixed(1).replace(/\.0$/, '') + '억';
+    if (num >= 1_0000) return (num / 1_0000).toFixed(1).replace(/\.0$/, '') + '만';
+    if (num >= 1_000) return (num / 1_000).toFixed(1).replace(/\.0$/, '') + '천';
+    return num.toString();
+}

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,8 +1,0 @@
-export function formatDate(iso: string) {
-    const date = new Date(iso);
-    return date.toLocaleDateString("ko-KR", {
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-    });
-}


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #38

---

### 🚀 어떤 기능을 구현했나요?
- 영상 및 댓글 정보에 숫자/날짜 포맷 유틸을 적용하여 가독성 개선

### 🔥 어떻게 해결했나요?
- `formatDate(date, withTime)` 함수에 시간 포함 여부를 제어하는 옵션 추가
- `formatNumber(num)` 함수로 조회수, 구독자 수, 좋아요 수 등을 단위(천/만/억)로 포맷했습니다.
- 기존 `date-format.ts` → `data-format.ts`로 이름 변경 후, 관련 컴포넌트에 적용했습니다.

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 날짜와 숫자 포맷이 UI에 의도한 대로 출력되는지
- 기존 포맷 로직이 남아 있거나 중복되지 않았는지

### 📚 참고 자료, 할 말
-