### PR TITLE
feat:  상세페이지 내 댓글 검색/필터링 구현 (#46)

### DIFF
--- a/src/components/common/SentimentBar/SentimentBar.tsx
+++ b/src/components/common/SentimentBar/SentimentBar.tsx
@@ -4,9 +4,12 @@ import { useState, useCallback } from 'react';
 import SentimentItem from './SentimentItem';
 import { SentimentRatio } from '@/types/video';
 
-interface EmotionBarProps {
+type SentimentType = 'POSITIVE' | 'NEGATIVE' | 'OTHER';
+
+interface SentimentBarProps {
     ratio?: SentimentRatio;
     size?: 'sm' | 'md';
+    onClick?: (sentiment: SentimentType) => void;
 }
 
 const COLORS = {
@@ -32,12 +35,23 @@ const COLORS = {
 
 const clampPercent = (value: number) => Math.max(0, Math.min(100, value));
 
-export default function SentimentBar({ ratio, size = 'md' }: EmotionBarProps) {
+export default function SentimentBar({ ratio, size = 'md', onClick }: SentimentBarProps) {
     const [hoveredKey, setHoveredKey] = useState<string | null>(null);
 
-    const handleClick = useCallback((label: string, percent: number) => {
-        console.log(`${label}: ${percent}%`);
-    }, []);
+    const handleClick = useCallback((key: string) => {
+        const map: Record<string, SentimentType> = {
+            positive: 'POSITIVE',
+            negative: 'NEGATIVE',
+            other: 'OTHER',
+        };
+        const sentiment = map[key.toLowerCase()];
+        console.log("감정 클릭됨", key, "→", sentiment);
+
+        if (onClick && sentiment) {
+            onClick(sentiment);
+        }
+    }, [onClick]);
+
 
     const hasValidData =
         ratio &&

--- a/src/components/common/SentimentBar/SentimentItem.tsx
+++ b/src/components/common/SentimentBar/SentimentItem.tsx
@@ -45,7 +45,7 @@ export default function SentimentItem(props: SentimentItemProps) {
                 width: displayWidth,
                 minWidth: shouldShowText ? '3rem' : '0',
             }}
-            onClick={() => onClick(label, percent)}
+            onClick={() => onClick(keyName, percent)}
             onMouseEnter={() => onHover(keyName)}
             onMouseLeave={() => onHover(null)}
         >

--- a/src/components/videos/SearchComment.tsx
+++ b/src/components/videos/SearchComment.tsx
@@ -1,15 +1,19 @@
 'use client';
-import {MagnifyingGlassIcon} from "@heroicons/react/24/outline";
-import {useState} from "react";
+import { MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { useState } from "react";
 
-export default function SearchComment() {
+interface Props {
+    onSearch: (q: string) => void;
+}
+
+export default function SearchComment({ onSearch }: Props) {
     const [search, setSearch] = useState('');
     const [isFocus, setFocus] = useState(false);
     const [isComposing, setIsComposing] = useState(false);
 
     const handleSearch = () => {
         if (!search.trim()) return;
-        console.log(search);
+        onSearch(search.trim());
         setSearch('');
     };
 

--- a/src/components/videos/SectionLayout.tsx
+++ b/src/components/videos/SectionLayout.tsx
@@ -4,14 +4,15 @@ interface Props {
     header: string;
     type?: string;
     children: React.ReactNode;
+    onSearch?: (q: string) => void;
 }
 
-export default function SectionLayout({ header, type, children }: Props) {
+export default function SectionLayout({ header, type, children, onSearch }: Props) {
     return (
         <div className="flex flex-col gap-4">
             <div className="flex flex-wrap justify-between gap-2">
                 <h1 className="text-lg font-semibold">{header}</h1>
-                {type === "search-comment" && <SearchComment />}
+                {type === "search-comment" && onSearch && <SearchComment onSearch={onSearch} />}
             </div>
             {children}
         </div>

--- a/src/components/videos/index.tsx
+++ b/src/components/videos/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import type { VideoResult } from "@/types/video";
+import type { VideoResult, Comment } from "@/types/video";
 import type { YouTubePlayerRef } from "@components/videos/video-info/YoutubePlayer";
 
 import VideoInfo from "@components/videos/video-info";
@@ -13,11 +13,14 @@ import TagList from "@components/common/Tag/TagList";
 import AISummary from "@components/common/AISummary";
 import SentimentBar from "@components/common/SentimentBar/SentimentBar";
 import WarningBanner from "@components/videos/WarningBanner";
-import {fetchVideoDetail} from "@/service/videoService";
+import { fetchVideoDetail } from "@/service/videoService";
 import LoadingSection from "@components/common/LoadingSection";
+import { fetchFilteredComments } from "@/service/searchService";
 
 export default function Detail({ videoId }: { videoId: string }) {
     const [data, setData] = useState<VideoResult | null>(null);
+    const [filteredComments, setFilteredComments] = useState<Comment[]>([]);
+    const [keywordComments, setKeywordComments] = useState<Comment[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(false);
     const playerRef = useRef<YouTubePlayerRef | null>(null);
@@ -27,6 +30,8 @@ export default function Detail({ videoId }: { videoId: string }) {
             try {
                 const res = await fetchVideoDetail(videoId);
                 setData(res);
+                setFilteredComments(res.comments);
+                setKeywordComments(res.comments);
             } catch (err) {
                 console.error("영상 정보를 불러오지 못했습니다:", err);
                 setError(true);
@@ -37,17 +42,43 @@ export default function Detail({ videoId }: { videoId: string }) {
         fetchData();
     }, [videoId]);
 
-
     const handleSeek = (timeString: string) => {
-        const parts = timeString.split(":").map(Number);
+        const parts = timeString.split(":" ).map(Number);
         const seconds = parts.reduce((acc, val, idx) => acc + val * Math.pow(60, parts.length - idx - 1), 0);
         playerRef.current?.seekToTime(seconds);
+    };
+
+    const handleFilterComments = async (filter: { q?: string; sentiment?: 'POSITIVE' | 'NEGATIVE' | 'OTHER' }) => {
+        try {
+            console.log("[전체 댓글 필터]", filter);
+            const results = await fetchFilteredComments({ videoId, ...filter });
+            console.log("[전체 댓글 응답]", results);
+            setFilteredComments(results);
+        } catch (err) {
+            console.error("댓글 필터링 실패:", err);
+        }
+    };
+
+    const handleKeywordFilter = async (keyword: string) => {
+        try {
+            console.log("[키워드 클릭]", keyword);
+            const results = await fetchFilteredComments({ videoId, keyword });
+            console.log("[키워드 댓글 응답]", results);
+            setKeywordComments(results);
+        } catch (err) {
+            console.error("키워드 댓글 필터링 실패:", err);
+        }
+    };
+
+    const handleSearch = async (q: string) => {
+        console.log("[검색어 입력됨]", q);
+        await handleFilterComments({ q });
     };
 
     if (loading) return <LoadingSection message="데이터를 불러오고 있습니다..." />;
     if (error || !data) return <div className="text-center mt-10 text-gray-500">영상을 불러올 수 없습니다.</div>;
 
-    const { analysis, comments } = data;
+    const { analysis } = data;
     const {
         summary,
         topComments,
@@ -70,9 +101,16 @@ export default function Detail({ videoId }: { videoId: string }) {
                     <SectionLayout header="좋아요 Top 5">
                         <CommentList comments={topComments} />
                     </SectionLayout>
-                    <SectionLayout header="전체 댓글 확인하기" type="search-comment">
-                        <SentimentBar ratio={sentimentDistribution} />
-                        <CommentList comments={comments} />
+                    <SectionLayout
+                        header="전체 댓글 확인하기"
+                        type="search-comment"
+                        onSearch={handleSearch}
+                    >
+                        <SentimentBar
+                            ratio={sentimentDistribution}
+                            onClick={(sentiment) => handleFilterComments({ sentiment })}
+                        />
+                        <CommentList comments={filteredComments} />
                     </SectionLayout>
                 </div>
                 <div className="col-auto flex flex-col gap-10">
@@ -86,8 +124,8 @@ export default function Detail({ videoId }: { videoId: string }) {
                         <CommentTimeChart data={commentHistogram} />
                     </SectionLayout>
                     <SectionLayout header="키워드 분석">
-                        <TagList tags={keywords} />
-                        <CommentList comments={comments} />
+                        <TagList tags={keywords} onTagClick={handleKeywordFilter} />
+                        <CommentList comments={keywordComments} />
                     </SectionLayout>
                 </div>
             </div>

--- a/src/service/searchService.ts
+++ b/src/service/searchService.ts
@@ -1,8 +1,26 @@
 import api from "@/lib/axios";
+import type { Comment } from "@/types/video";
 
 export const searchByQuery = async (query: string) => {
     const res = await api.get("/search", {
         params: { query },
     });
     return res.data.data;
+};
+
+export const fetchFilteredComments = async ({
+                                                videoId,
+                                                q,
+                                                sentiment,
+                                                keyword,
+                                            }: {
+    videoId: string;
+    q?: string;
+    sentiment?: 'POSITIVE' | 'NEGATIVE' | 'OTHER';
+    keyword?: string;
+}): Promise<Comment[]> => {
+    console.log("[API 호출됨]", { videoId, q, sentiment, keyword });
+    const params = q ? { q } : sentiment ? { sentiment } : keyword ? { keyword } : {};
+    const res = await api.get(`/videos/${videoId}/comments`, { params });
+    return res.data.data.results;
 };


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #46

---

### 🚀 어떤 기능을 구현했나요?
- 전체 댓글 영역에서 검색어 필터링 기능 추가
- 감정 클릭 시 해당 감정 댓글만 표시
- 키워드 분석 섹션과 댓글 필터 상태 분리 처리

### 🔥 어떻게 해결했나요?
- `Detail` 컴포넌트에 검색/감정/키워드 핸들러 분리
- `SectionLayout`에 `onSearch` props 전달
- `filteredComments`, `keywordComments`로 상태 분리 관리

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 댓글 필터링 동작이 의도대로 작동하는지
- 필터 결과가 다른 섹션에 영향 주지 않는지

### 📚 참고 자료, 할 말
- 
