### PR TITLE
fix: OAuth 로그인 시 환경별 redirect_uri 동적 처리 추가 (#53)

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -11,13 +11,13 @@ function LoginFallbackContent() {
         unauthorized: "로그인 인증이 실패했습니다. 다시 시도해주세요.",
         invalid: "로그인 정보가 유효하지 않습니다.",
         '': "다시 로그인해주세요.",
-    }[error ?? ''] || "알 수 없는 오류가 발생했습니다.";
+    }[error ?? ''] ?? "알 수 없는 오류가 발생했습니다.";
 
     return (
         <div className="flex flex-col items-center justify-center h-screen text-center">
             <p className="text-xl font-semibold">{errorMessage}</p>
             <button
-                className="mt-10 px-4 py-2 bg-red-600 text-white rounded-xl"
+                className="mt-10 px-4 py-2 bg-gray-600 text-white rounded-xl cursor-pointer "
                 onClick={() => window.location.href = "/"}
             >
                 홈으로 돌아가기

--- a/src/app/login/success/page.tsx
+++ b/src/app/login/success/page.tsx
@@ -1,39 +1,41 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { AxiosError } from 'axios';
 import { useAuth } from '@/contexts/AuthContext';
 import { fetchAuthUser } from '@/service/authService';
 
 export default function LoginSuccessPage() {
     const router = useRouter();
     const { setUserData } = useAuth();
-    const called = useRef(false);  // ✅ 실행 여부 추적
 
     useEffect(() => {
-        if (called.current) return;  // ✅ 이미 호출되었으면 중단
-        called.current = true;
-
-        const login = async () => {
+        let mounted = true;
+        (async () => {
             try {
                 const user = await fetchAuthUser();
-                console.log("로그인 유저 정보:", user);
+                if (!mounted) return;
 
                 if (!user?.userName) {
-                    console.warn("유저 정보 누락:", user);
-                    return router.push("/?error=invalid");
+                    router.replace('/login?error=invalid');
+                    return;
                 }
 
                 setUserData(user);
-                router.push("/");
-
-            } catch (error) {
-                console.error("로그인 처리 중 예외:", error);
-                router.push("/?error=login-fail");
+                router.replace('/');
+            } catch (err) {
+                if (!mounted) return;
+                const ax = err as AxiosError;
+                const status = ax.response?.status;
+                router.replace(
+                    status === 401 || status === 403
+                        ? '/login?error=unauthenticated'
+                        : '/login?error=login-fail'
+                );
             }
-        };
-
-        login();
+        })();
+        return () => { mounted = false; };
     }, [router, setUserData]);
 
     return (

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,16 +1,17 @@
 'use client';
 
-import { createContext, useContext, useState, useEffect } from 'react';
+import { createContext, useContext, useState, useEffect, useMemo, useCallback } from 'react';
 import { UserInfoResponse } from '@/types/user';
 import { useRouter } from 'next/navigation';
 import { logoutUser } from '@/service/authService';
+import { buildRedirectUri, getApiBaseUrl } from '@/lib/url';
 
 interface AuthContextType {
     isLoggedIn: boolean;
-    user: UserInfoResponse["data"] | null;
+    user: UserInfoResponse['data'] | null;
     handleLogin: () => void;
-    handleLogout: () => void;
-    setUserData: (user: UserInfoResponse["data"] | null) => void;
+    handleLogout: () => Promise<void>;
+    setUserData: (user: UserInfoResponse['data'] | null) => void;
 }
 
 const AuthContext = createContext<AuthContextType | null>(null);
@@ -18,9 +19,9 @@ const AuthContext = createContext<AuthContextType | null>(null);
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
     const router = useRouter();
     const [isLoggedIn, setIsLoggedIn] = useState(false);
-    const [user, setUser] = useState<UserInfoResponse["data"] | null>(null);
+    const [user, setUser] = useState<UserInfoResponse['data'] | null>(null);
 
-    const setUserData = (userData: UserInfoResponse["data"] | null) => {
+    const setUserData = useCallback((userData: UserInfoResponse['data'] | null) => {
         if (userData) {
             localStorage.setItem('auth', JSON.stringify(userData));
             setUser(userData);
@@ -30,28 +31,31 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
             setUser(null);
             setIsLoggedIn(false);
         }
-    };
+    }, []);
 
-    const handleLogin = () => {
-        window.location.href = 'https://knu-sosuso.com/oauth2/authorization/google';
-    };
+    const handleLogin = useCallback(() => {
+        const apiUrl = getApiBaseUrl();
+        const redirectUrl = encodeURIComponent(buildRedirectUri());
+        window.location.assign(
+            `${apiUrl}/oauth2/authorization/google?redirect_uri=${redirectUrl}`
+        );
+    }, []);
 
-    const handleLogout = async () => {
+    const handleLogout = useCallback(async () => {
         try {
             await logoutUser();
         } catch (error) {
-            console.error("로그아웃 실패", error);
+            console.error('로그아웃 실패', error);
         } finally {
             setUserData(null);
-            router.push("/");
-            console.log("로그아웃 완료");
+            router.push('/');
+            console.log('로그아웃 완료');
         }
-    };
+    }, [router, setUserData]);
 
     useEffect(() => {
         const authString = localStorage.getItem('auth');
         if (!authString) return;
-
         try {
             const parsed = JSON.parse(authString);
             setUser(parsed);
@@ -62,15 +66,15 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         }
     }, []);
 
-    return (
-        <AuthContext.Provider value={{ isLoggedIn, user, handleLogin, handleLogout, setUserData }}>
-            {children}
-        </AuthContext.Provider>
+    const value = useMemo(
+        () => ({ isLoggedIn, user, handleLogin, handleLogout, setUserData }),
+        [isLoggedIn, user, handleLogin, handleLogout, setUserData]
     );
+    return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };
 
 export const useAuth = () => {
-    const context = useContext(AuthContext);
-    if (!context) throw new Error('useAuth must be used within AuthProvider');
-    return context;
+    const ctx = useContext(AuthContext);
+    if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+    return ctx;
 };

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,7 +1,8 @@
-import axios from "axios";
+import axios from 'axios';
+import { getApiBaseUrl } from '@/lib/url';
 
 const api = axios.create({
-    baseURL: "https://knu-sosuso.com/api",
+    baseURL: `${getApiBaseUrl()}/api`,
     withCredentials: true,
 });
 

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,0 +1,30 @@
+function normalizeBase(url?: string): string | null {
+    if (!url) return null;
+    const trimmed = url.replace(/\/+$/, '');
+    if (!/^https?:\/\//.test(trimmed)) return null;
+    return trimmed;
+}
+
+export function getApiBaseUrl(): string {
+    return normalizeBase(process.env.NEXT_PUBLIC_API_BASE_URL) ?? 'https://knu-sosuso.com';
+}
+
+export function getBaseUrl(): string {
+    // 1순위: env
+    const fromEnv = normalizeBase(process.env.NEXT_PUBLIC_BASE_URL);
+    if (fromEnv) return fromEnv;
+
+    // 2순위: 브라우저 현재 origin
+    if (typeof window !== 'undefined' && window.location?.origin) {
+        return window.location.origin;
+    }
+
+    // 3순위: 안전 기본값
+    return 'https://sosuso-client.vercel.app';
+}
+
+export const LOGIN_SUCCESS_PATH = '/login/success';
+
+export function buildRedirectUri() {
+    return `${getBaseUrl()}${LOGIN_SUCCESS_PATH}`;
+}


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #53

---

## 🚀 구현 내용
- OAuth 로그인에 환경별 `redirect_uri` 적용
- `/login/success`에서 세션 확인 → `/` 리다이렉트
- URL 유틸 도입: `getApiBaseUrl`, `getBaseUrl`, `buildRedirectUri`
- axios `baseURL`을 env + `/api`로 통일

## 🔥 해결 방식
- `handleLogin`에서 `redirect_uri=${encodeURIComponent(buildRedirectUri())}`로 백엔드 호출
- 성공 페이지에서 `/auth/login` 호출 성공 시 상태 저장 후 `/` 이동

## 📝 리뷰 포인트
- `url.ts` 정규식, `buildRedirectUri()` 결과 확인

## 📚 참고
- 최종 리다이렉트는 백엔드 화이트리스트 검증 후 302로 처리 필요
