### PR TITLE
fix(scraps): 비로그인 시 API 요청 차단으로 400 오류 방지 (#55)

### DIFF
--- a/src/components/scraps/index.tsx
+++ b/src/components/scraps/index.tsx
@@ -10,11 +10,12 @@ import type {VideoSummaryItem} from "@/types/video-summary";
 
 export default function Scraps() {
     const { isLoggedIn, handleLogin } = useAuth();
-    const [isLoading, setIsLoading] = useState(true);
+    const [isLoading, setIsLoading] = useState(false);
     const [isError, setIsError] = useState(false);
     const [videoList, setVideoList] = useState<VideoSummaryItem[]>([]);
 
     useEffect(() => {
+        if (!isLoggedIn) return;
         const fetch = async () => {
             console.log("[스크랩] API 요청 시작");
             setIsLoading(true);
@@ -33,10 +34,10 @@ export default function Scraps() {
         };
 
         fetch();
-    }, []);
+    }, [isLoggedIn]);
 
     if (isLoading) return <LoadingSection message="데이터를 불러오고 있습니다..." />;
-    if (isError) return <div className="text-center text-gray-500 py-10">인기 영상 정보를 불러오지 못했어요.</div>;
+    if (isError) return <div className="text-center text-gray-500 py-10">스크랩 정보를 불러오지 못했어요.</div>;
 
     return (
         <div className="w-full flex justify-center px-4 py-5">


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #55

---

### 🚀 어떤 기능을 구현했나요?
- 스크랩 페이지에서 비로그인 상태일 때 발생하던 렌더링(400) 오류 수정

### 🔥 어떻게 해결했나요?
- `isLoggedIn`이 `true`일 때만 `fetchScrapsVideos()` 호출하도록 조건 추가
- 불필요한 로딩/에러 상태 발생 방지

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 로그인 상태 변화 시 정상적으로 스크랩 리스트가 다시 로드되는지
- 비로그인 상태에서 불필요한 API 호출이 완전히 차단되는지

### 📚 참고 자료, 할 말
-