### PR TITLE
refactor: 영상 상세 API 분리 및 병렬 로딩 구현 (#65)

### DIFF
--- a/src/components/common/AISummary.tsx
+++ b/src/components/common/AISummary.tsx
@@ -1,7 +1,7 @@
 import EmptyState from "@components/common/EmptyState";
 
 type AISummaryProps = {
-    summary?: string;
+    summary?: string | null;
     size?: "sm" | "md";
 };
 

--- a/src/components/videos/index.tsx
+++ b/src/components/videos/index.tsx
@@ -1,9 +1,5 @@
 "use client";
 
-import {useCallback, useEffect, useRef, useState} from "react";
-import type { VideoResult, Comment } from "@/types/video.types";
-import type { YouTubePlayerRef } from "@components/videos/video-info/YoutubePlayer";
-
 import VideoInfo from "@components/videos/video-info";
 import SectionLayout from "@components/videos/SectionLayout";
 import CommentList from "@components/common/Comment/CommentList";
@@ -13,135 +9,143 @@ import TagList from "@components/common/Tag/TagList";
 import AISummary from "@components/common/AISummary";
 import SentimentBar from "@components/common/SentimentBar/SentimentBar";
 import WarningBanner from "@components/videos/WarningBanner";
-import { fetchVideoDetail } from "@/services/video.service";
 import LoadingSection from "@components/common/LoadingSection";
-import { fetchFilteredComments } from "@/services/search.service";
+import {useVideoDetail} from "@/hooks/useVideoDetail";
 
-export default function Detail({ videoId }: { videoId: string }) {
-    const [data, setData] = useState<VideoResult | null>(null);
-    const [filteredComments, setFilteredComments] = useState<Comment[]>([]);
-    const [keywordComments, setKeywordComments] = useState<Comment[]>([]);
-    const [selectedKeyword, setSelectedKeyword] = useState<string | null>(null);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(false);
-    const playerRef = useRef<YouTubePlayerRef | null>(null);
-
-    useEffect(() => {
-        const fetchData = async () => {
-            try {
-                const res = await fetchVideoDetail(videoId);
-                setData(res);
-                setFilteredComments(res.comments);
-                setKeywordComments(res.comments);
-            } catch (err) {
-                console.error("영상 정보를 불러오지 못했습니다:", err);
-                setError(true);
-            } finally {
-                setLoading(false);
-            }
-        };
-        fetchData();
-    }, [videoId]);
-
-    const handleSeek = (timeString: string) => {
-        const parts = timeString.split(":").map(Number);
-        const seconds = parts.reduce((acc, val, idx) => acc + val * Math.pow(60, parts.length - idx - 1), 0);
-        playerRef.current?.seekToTime(seconds);
-    };
-
-    const handleFilterComments = async (filter: { q?: string; sentiment?: 'POSITIVE' | 'NEGATIVE' | 'OTHER' }) => {
-        try {
-            const results = await fetchFilteredComments({ videoId, ...filter });
-            setFilteredComments(results);
-        } catch (err) {
-            console.error("댓글 필터링 실패:", err);
-        }
-    };
-
-    const handleKeywordFilter = useCallback(async (keyword: string) => {
-        try {
-            setSelectedKeyword(keyword);
-            const results = await fetchFilteredComments({ videoId, keyword });
-            setKeywordComments(results);
-        } catch (err) {
-            console.error("키워드 댓글 필터링 실패:", err);
-        }
-    }, [videoId]);
-
-    const handleSearch = async (q: string) => {
-        await handleFilterComments({ q });
-    };
-
-    useEffect(() => {
-        if (!loading && Array.isArray(data?.analysis?.keywords) && data.analysis.keywords.length > 0) {
-            const firstKeyword = data.analysis.keywords[0];
-            setSelectedKeyword(firstKeyword);
-            handleKeywordFilter(firstKeyword);
-        }
-    }, [loading, data, handleKeywordFilter]);
-
-    if (loading) return <LoadingSection message="데이터를 불러오고 있습니다..." />;
-    if (error || !data) return <div className="text-center mt-10 text-gray-500">영상을 불러올 수 없습니다.</div>;
-
-    const { analysis } = data;
+export default function Detail({videoId}: { videoId: string }) {
     const {
-        summary,
-        topComments,
-        languageDistribution,
-        sentimentDistribution,
-        popularTimestamps,
-        commentHistogram,
-        keywords,
-    } = analysis;
+        basicInfo,
+        analysisInfo,
+        comments,
+        aiAnalysis,
+        filteredComments,
+        keywordComments,
+        selectedKeyword,
+        isLoading,
+        error,
+        playerRef,
+        handleSeek,
+        handleFilterComments,
+        handleKeywordFilter,
+        handleSearch,
+    } = useVideoDetail(videoId);
+
+    // 기본 정보 로딩 중이거나 에러 시
+    if (isLoading.basic) return <LoadingSection message="데이터를 불러오고 있습니다..."/>;
+    if (error || !basicInfo) return <div className="text-center mt-10 text-gray-500">영상을 불러올 수 없습니다.</div>;
 
     return (
         <div className="flex flex-col w-full px-3 py-5 items-center max-w-[1000px] m-auto gap-5">
-            {analysis.isWarning && <WarningBanner />}
+            {aiAnalysis?.isWarning && <WarningBanner/>}
 
-            <VideoInfo data={data} onPlayerReady={(ref) => (playerRef.current = ref)} />
+            <VideoInfo
+                data={{
+                    video: basicInfo.video,
+                    channel: basicInfo.channel,
+                    analysis: {
+                        summary: aiAnalysis?.summary ?? '',
+                        isWarning: aiAnalysis?.isWarning ?? false,
+                        topComments: analysisInfo?.topComments ?? [],
+                        languageDistribution: aiAnalysis?.languageDistribution ?? [],
+                        sentimentDistribution: aiAnalysis?.sentimentDistribution ?? {
+                            positive: 0,
+                            negative: 0,
+                            other: 0
+                        },
+                        popularTimestamps: analysisInfo?.popularTimestamps ?? [],
+                        commentHistogram: analysisInfo?.commentHistogram ?? [],
+                        keywords: aiAnalysis?.keywords ?? [],
+                    },
+                    comments: comments,
+                }}
+                onPlayerReady={(ref) => (playerRef.current = ref)}
+            />
 
             <div className="grid grid-cols-1 md:grid-cols-2 w-full gap-5 md:gap-10">
                 <div className="flex flex-col gap-5 md:gap-10">
                     <SectionLayout header="AI 전체 요약">
-                        <AISummary summary={summary} />
+                        {isLoading.ai ? (
+                            <LoadingSection message="AI 분석 중..."/>
+                        ) : (
+                            <AISummary summary={aiAnalysis?.summary ?? null}/>
+                        )}
                     </SectionLayout>
+
                     <SectionLayout header="좋아요 Top 5">
-                        <CommentList comments={topComments} />
+                        {isLoading.analysis ? (
+                            <LoadingSection message="인기 댓글 로딩 중..."/>
+                        ) : (
+                            <CommentList comments={analysisInfo?.topComments ?? []}/>
+                        )}
                     </SectionLayout>
+
                     <SectionLayout
                         header="전체 댓글 확인하기"
                         type="search-comment"
                         onSearch={handleSearch}
                     >
-                        <SentimentBar
-                            ratio={sentimentDistribution}
-                            onClick={(sentiment) => handleFilterComments({ sentiment })}
-                        />
-                        <CommentList comments={filteredComments} />
+                        {isLoading.ai ? (
+                            <LoadingSection message="감정 분석 중..."/>
+                        ) : (
+                            <SentimentBar
+                                ratio={aiAnalysis?.sentimentDistribution ?? {positive: 0, negative: 0, other: 0}}
+                                onClick={(sentiment) => handleFilterComments({sentiment})}
+                            />
+                        )}
+                        {isLoading.comments ? (
+                            <LoadingSection message="댓글 로딩 중..."/>
+                        ) : (
+                            <CommentList comments={filteredComments}/>
+                        )}
                     </SectionLayout>
                 </div>
 
                 <div className="flex flex-col gap-5 md:gap-10">
                     <SectionLayout header="언어 비율">
-                        <LanguageChart data={languageDistribution} />
+                        {isLoading.ai ? (
+                            <LoadingSection message="언어 분석 중..."/>
+                        ) : (
+                            <LanguageChart data={aiAnalysis?.languageDistribution ?? []}/>
+                        )}
                     </SectionLayout>
+
                     <SectionLayout header="가장 많이 언급한 시간대">
-                        <TagList
-                            tags={(popularTimestamps ?? []).map(t => t.time)}
-                            onTagClick={handleSeek}
-                        />
+                        {isLoading.analysis ? (
+                            <LoadingSection message="타임스탬프 분석 중..."/>
+                        ) : (
+                            <TagList
+                                tags={(analysisInfo?.popularTimestamps ?? []).map(t => t.time)}
+                                onTagClick={handleSeek}
+                            />
+                        )}
                     </SectionLayout>
+
                     <SectionLayout header="댓글 작성 시간대">
-                        <CommentTimeChart data={commentHistogram} />
+                        {isLoading.analysis ? (
+                            <LoadingSection message="시간대 분석 중..."/>
+                        ) : (
+                            <CommentTimeChart data={analysisInfo?.commentHistogram ?? []}/>
+                        )}
                     </SectionLayout>
+
                     <SectionLayout header="키워드 분석">
-                        <TagList
-                            tags={keywords}
-                            onTagClick={handleKeywordFilter}
-                            selectedTag={selectedKeyword}
-                            highlightSelected={true}
-                        />
-                        <CommentList comments={keywordComments} />
+                        {isLoading.ai ? (
+                            <LoadingSection message="키워드 분석 중..."/>
+                        ) : (
+                            <>
+                                <TagList
+                                    tags={aiAnalysis?.keywords ?? []}
+                                    onTagClick={handleKeywordFilter}
+                                    selectedTag={selectedKeyword}
+                                    highlightSelected={true}
+                                />
+                                {isLoading.comments ? (
+                                    <LoadingSection message="댓글 로딩 중..."/>
+                                ) : (
+                                    <CommentList comments={keywordComments}/>
+                                )}
+                            </>
+                        )}
                     </SectionLayout>
                 </div>
             </div>

--- a/src/hooks/useVideoDetail.ts
+++ b/src/hooks/useVideoDetail.ts
@@ -1,0 +1,155 @@
+import {useState, useEffect, useCallback, useRef} from "react";
+import type {Comment, VideoBasicInfo, VideoAnalysisInfo, VideoAIAnalysis} from "@/types/video.types";
+import type {YouTubePlayerRef} from "@components/videos/video-info/YoutubePlayer";
+import {fetchVideoBasic, fetchVideoAnalysis, fetchVideoComments, fetchVideoAI} from "@/services/video.service";
+import {fetchFilteredComments} from "@/services/search.service";
+
+export function useVideoDetail(videoId: string) {
+    // 각 섹션별 독립적인 상태 관리
+    const [basicInfo, setBasicInfo] = useState<VideoBasicInfo | null>(null);
+    const [analysisInfo, setAnalysisInfo] = useState<VideoAnalysisInfo | null>(null);
+    const [comments, setComments] = useState<Comment[]>([]);
+    const [aiAnalysis, setAIAnalysis] = useState<VideoAIAnalysis | null>(null);
+
+    const [filteredComments, setFilteredComments] = useState<Comment[]>([]);
+    const [keywordComments, setKeywordComments] = useState<Comment[]>([]);
+    const [selectedKeyword, setSelectedKeyword] = useState<string | null>(null);
+
+    // 각 섹션별 로딩 상태
+    const [isLoading, setIsLoading] = useState({
+        basic: true,
+        analysis: true,
+        comments: true,
+        ai: true,
+    });
+
+    const [error, setError] = useState(false);
+    const playerRef = useRef<YouTubePlayerRef | null>(null);
+
+    // 데이터 fetching
+    useEffect(() => {
+        let mounted = true;
+
+        fetchVideoBasic(videoId)
+            .then((result) => {
+                if (!mounted) return;
+                setBasicInfo(result);
+            })
+            .catch((err) => {
+                console.error("기본 정보 로딩 실패:", err);
+                setError(true);
+            })
+            .finally(() => {
+                if (!mounted) return;
+                setIsLoading((prev) => ({...prev, basic: false}));
+            });
+
+        fetchVideoAnalysis(videoId)
+            .then((result) => {
+                if (!mounted) return;
+                setAnalysisInfo(result);
+            })
+            .catch((err) => {
+                console.error("분석 정보 로딩 실패:", err);
+            })
+            .finally(() => {
+                if (!mounted) return;
+                setIsLoading((prev) => ({...prev, analysis: false}));
+            });
+
+        fetchVideoComments(videoId)
+            .then((result) => {
+                if (!mounted) return;
+                setComments(result);
+                setFilteredComments(result);
+                setKeywordComments(result);
+            })
+            .catch((err) => {
+                console.error("댓글 로딩 실패:", err);
+            })
+            .finally(() => {
+                if (!mounted) return;
+                setIsLoading((prev) => ({...prev, comments: false}));
+            });
+
+        fetchVideoAI(videoId)
+            .then((result) => {
+                if (!mounted) return;
+                setAIAnalysis(result);
+            })
+            .catch((err) => {
+                console.error("AI 분석 로딩 실패:", err);
+            })
+            .finally(() => {
+                if (!mounted) return;
+                setIsLoading((prev) => ({...prev, ai: false}));
+            });
+
+        return () => {
+            mounted = false;
+        };
+    }, [videoId]);
+
+    // Handlers
+    const handleSeek = useCallback((timeString: string) => {
+        const parts = timeString.split(":").map(Number);
+        const seconds = parts.reduce((acc, val, idx) => acc + val * Math.pow(60, parts.length - idx - 1), 0);
+        playerRef.current?.seekToTime(seconds);
+    }, []);
+
+    const handleFilterComments = useCallback(async (filter: {
+        q?: string;
+        sentiment?: 'POSITIVE' | 'NEGATIVE' | 'OTHER'
+    }) => {
+        try {
+            const results = await fetchFilteredComments({videoId, ...filter});
+            setFilteredComments(results);
+        } catch (err) {
+            console.error("댓글 필터링 실패:", err);
+        }
+    }, [videoId]);
+
+    const handleKeywordFilter = useCallback(async (keyword: string) => {
+        try {
+            setSelectedKeyword(keyword);
+            const results = await fetchFilteredComments({videoId, keyword});
+            setKeywordComments(results);
+        } catch (err) {
+            console.error("키워드 댓글 필터링 실패:", err);
+        }
+    }, [videoId]);
+
+    const handleSearch = useCallback(async (q: string) => {
+        await handleFilterComments({q});
+    }, [handleFilterComments]);
+
+    // 첫 키워드 자동 선택
+    useEffect(() => {
+        if (!isLoading.ai && Array.isArray(aiAnalysis?.keywords) && aiAnalysis.keywords.length > 0) {
+            const firstKeyword = aiAnalysis.keywords[0];
+            setSelectedKeyword(firstKeyword);
+            void handleKeywordFilter(firstKeyword);
+        }
+    }, [isLoading.ai, aiAnalysis, handleKeywordFilter]);
+
+    return {
+        basicInfo,
+        analysisInfo,
+        comments,
+        aiAnalysis,
+        filteredComments,
+        keywordComments,
+        selectedKeyword,
+
+        isLoading,
+        error,
+
+        playerRef,
+
+        // Handlers
+        handleSeek,
+        handleFilterComments,
+        handleKeywordFilter,
+        handleSearch,
+    };
+}

--- a/src/services/video.service.ts
+++ b/src/services/video.service.ts
@@ -1,6 +1,16 @@
 import api from "@/lib/axios";
 import {BaseApiResponse} from "@/types/common.types";
-import {Comment, VideoResult} from "@/types/video.types";
+import {
+    Comment,
+    VideoResult,
+    VideoBasicResponse,
+    VideoAnalysisResponse,
+    VideoCommentsResponse,
+    VideoAIResponse,
+    VideoBasicInfo,
+    VideoAnalysisInfo,
+    VideoAIAnalysis
+} from "@/types/video.types";
 import {VideoSummaryItem} from "@/types/video-summary.types";
 
 const normalizeSentiment = (comments: Comment[] | null | undefined): Comment[] =>
@@ -8,6 +18,31 @@ const normalizeSentiment = (comments: Comment[] | null | undefined): Comment[] =
         ...comment,
         sentiment: comment.sentiment?.toLowerCase?.() as 'positive' | 'negative' | 'other',
     }));
+
+export const fetchVideoBasic = async (apiVideoId: string): Promise<VideoBasicInfo> => {
+    const res = await api.get<VideoBasicResponse>(`/videos/${apiVideoId}/basic`);
+    return res.data.data;
+};
+
+export const fetchVideoAnalysis = async (apiVideoId: string): Promise<VideoAnalysisInfo> => {
+    const res = await api.get<VideoAnalysisResponse>(`/videos/${apiVideoId}/analysis`);
+    const raw = res.data.data;
+
+    return {
+        ...raw,
+        topComments: normalizeSentiment(raw.topComments),
+    };
+};
+
+export const fetchVideoComments = async (apiVideoId: string): Promise<Comment[]> => {
+    const res = await api.get<VideoCommentsResponse>(`/videos/${apiVideoId}/comments/all`);
+    return normalizeSentiment(res.data.data);
+};
+
+export const fetchVideoAI = async (apiVideoId: string): Promise<VideoAIAnalysis> => {
+    const res = await api.get<VideoAIResponse>(`/videos/${apiVideoId}/ai`);
+    return res.data.data;
+};
 
 export const fetchVideoDetail = async (apiVideoId: string): Promise<VideoResult> => {
     const res = await api.get<BaseApiResponse<VideoResult>>(`/videos/${apiVideoId}`);

--- a/src/types/video.types.ts
+++ b/src/types/video.types.ts
@@ -1,10 +1,5 @@
 import {BaseApiResponse} from "./common.types";
 
-export type VideoSearchResponse = BaseApiResponse<{
-    searchType: 'URL' | 'CHANNEL';
-    results: VideoResult[];
-}>;
-
 export interface VideoResult {
     video: VideoDetail;
     channel: Channel;
@@ -72,3 +67,27 @@ export interface HourlyCommentCount {
     hour: string;
     count: number;
 }
+
+export interface VideoBasicInfo {
+    video: VideoDetail;
+    channel: Channel;
+}
+
+export interface VideoAnalysisInfo {
+    commentHistogram: HourlyCommentCount[];
+    popularTimestamps: TimestampMention[];
+    topComments: Comment[];
+}
+
+export interface VideoAIAnalysis {
+    summary: string | null;
+    isWarning: boolean;
+    languageDistribution: LanguageRatio[];
+    sentimentDistribution: SentimentRatio;
+    keywords: string[];
+}
+
+export type VideoBasicResponse = BaseApiResponse<VideoBasicInfo>;
+export type VideoAnalysisResponse = BaseApiResponse<VideoAnalysisInfo>;
+export type VideoCommentsResponse = BaseApiResponse<Comment[]>;
+export type VideoAIResponse = BaseApiResponse<VideoAIAnalysis>;


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #65

### 🚀 어떤 기능을 구현했나요?
영상 상세 페이지 API를 4개로 분리하여 병렬 로딩 구현

### 🔥 어떻게 해결했나요?
- 4개 API를 독립적으로 호출하여 완료되는 즉시 렌더링
- useVideoDetail 커스텀 훅으로 로직과 UI 분리
- 각 섹션별 로딩 상태 관리로 점진적 렌더링

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- useVideoDetail.ts의 독립적인 API 호출 로직
- 각 섹션별 조건부 렌더링 처리

### 📚 참고 자료, 할 말
- Home 페이지의 useMainPageData 패턴과 일관성 유지