### PR TITLE
feat: 전체 댓글 더보기 버튼 구현 (#67)

### DIFF
--- a/src/components/common/Comment/CommentList.tsx
+++ b/src/components/common/Comment/CommentList.tsx
@@ -1,23 +1,42 @@
 import CommentItem from "./CommentItem";
-import type { Comment as CommentType } from "@/types/video.types";
+import type {Comment as CommentType} from "@/types/video.types";
 import NoCommentItem from "@components/common/Comment/NoCommentItem";
+import {useLoadMore} from "@/hooks/useLoadMore";
 
 type Props = {
     comments: CommentType[];
 };
 
-export default function CommentList({ comments }: Props) {
+export default function CommentList({comments}: Props) {
+    const {displayedItems, hasMore, loadMore} = useLoadMore({
+        items: comments,
+        itemsPerPage: 20,
+    });
+
     if (!comments || comments.length === 0) {
-        return (
-            <NoCommentItem />
-        );
+        return <NoCommentItem/>;
     }
 
     return (
         <div className="flex flex-col gap-2">
-            {comments.map((comment, index) => (
-                <CommentItem key={index} {...comment} />
+            {displayedItems.map((comment, index) => (
+                <CommentItem key={comment.id || index} {...comment} />
             ))}
+
+            {hasMore && (
+                <button
+                    onClick={loadMore}
+                    className="w-full py-3 mt-2 rounded-lg bg-gray-100 hover:bg-gray-200 transition-colors text-sm text-gray-600 font-medium"
+                >
+                    댓글 더보기
+                </button>
+            )}
+
+            {!hasMore && comments.length > 20 && (
+                <div className="w-full py-3 text-center text-sm text-gray-400">
+                    모든 댓글을 불러왔습니다
+                </div>
+            )}
         </div>
     );
 }

--- a/src/hooks/useLoadMore.ts
+++ b/src/hooks/useLoadMore.ts
@@ -1,0 +1,37 @@
+import {useState, useEffect} from 'react';
+
+interface UseLoadMoreProps<T> {
+    items: T[];
+    itemsPerPage?: number;
+}
+
+export function useLoadMore<T>({items, itemsPerPage = 20}: UseLoadMoreProps<T>) {
+    const [displayedItems, setDisplayedItems] = useState<T[]>([]);
+    const [currentPage, setCurrentPage] = useState(0);
+
+    // 아이템 변경 시 초기화
+    useEffect(() => {
+        const initialItems = items.slice(0, itemsPerPage);
+        setDisplayedItems(initialItems);
+        setCurrentPage(0);
+    }, [items, itemsPerPage]);
+
+    // 더보기
+    const loadMore = () => {
+        const nextPage = currentPage + 1;
+        const startIndex = 0;
+        const endIndex = (nextPage + 1) * itemsPerPage;
+        const newItems = items.slice(startIndex, endIndex);
+
+        setDisplayedItems(newItems);
+        setCurrentPage(nextPage);
+    };
+
+    const hasMore = displayedItems.length < items.length;
+
+    return {
+        displayedItems,
+        hasMore,
+        loadMore,
+    };
+}


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #67 

---

### 🚀 어떤 기능을 구현했나요?
- 전체 댓글을 한 번에 렌더링하지 않고 20개씩 나눠서 표시하는 더보기 기능 구현

### 🔥 어떻게 해결했나요?
- 전체 댓글 데이터를 프론트에서 20개씩 슬라이싱하여 표시
- 더보기 버튼 클릭 시 다음 20개 추가
- useLoadMore 커스텀 훅으로 로직 분리
- 모든 댓글 로드 시 완료 메시지 표시

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- useLoadMore.ts의 페이징 로직
- CommentList.tsx의 더보기 버튼 UI

### 📚 참고 자료, 할 말
- 초기 렌더링 성능 개선 및 사용자가 로딩을 제어할 수 있도록 개선. 
- 무한 스크롤 방식 대신 더보기 버튼 방식을 채택하여 의도하지 않은 로딩 방지 및 스크롤 위치 유지 개선