### PR TITLE
refactor: 인기 급상승 API 변경 및 카테고리 제거 (#69)

### DIFF
--- a/src/components/trending/index.tsx
+++ b/src/components/trending/index.tsx
@@ -1,35 +1,25 @@
 'use client';
 
-import { useEffect, useState } from "react";
-import CategoryBar from "@components/trending/CategoryBar";
+import {useEffect, useState} from "react";
 import VideoSummaryList from "@components/common/VideoSummary/VideoSummaryList";
-import type { VideoSummaryItem } from "@/types/video-summary.types";
-import { fetchTrendingVideos } from "@/services/video.service";
+import type {VideoSummaryItem} from "@/types/video-summary.types";
+import {fetchTrendingVideos} from "@/services/video.service";
 import LoadingSection from "@components/common/LoadingSection";
 
-type CategoryType = "latest" | "music" | "game";
-
-const categories: { label: string; value: CategoryType }[] = [
-    { label: "최신", value: "latest" },
-    { label: "음악", value: "music" },
-    { label: "게임", value: "game" },
-];
-
 export default function Trending() {
-    const [isSelected, setIsSelected] = useState<CategoryType>("latest");
     const [videoList, setVideoList] = useState<VideoSummaryItem[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [isError, setIsError] = useState(false);
-    const maxResults = 7;
+    const maxResults = 10;
 
     useEffect(() => {
         const fetch = async () => {
-            console.log("[인기급상승] API 요청 시작", isSelected, maxResults);
+            console.log("[인기급상승] API 요청 시작", maxResults);
             setIsLoading(true);
             setIsError(false);
 
             try {
-                const result = await fetchTrendingVideos(isSelected, maxResults);
+                const result = await fetchTrendingVideos(maxResults);
                 console.log("[인기급상승] API 응답 성공", result);
                 setVideoList(result);
             } catch (err) {
@@ -41,9 +31,9 @@ export default function Trending() {
         };
 
         fetch();
-    }, [isSelected]);
+    }, []);
 
-    if (isLoading) return <LoadingSection message="데이터를 불러오고 있습니다..." />;
+    if (isLoading) return <LoadingSection message="데이터를 불러오고 있습니다..."/>;
     if (isError) return <div className="text-center text-gray-500 py-10">인기 영상 정보를 불러오지 못했어요.</div>;
 
     return (
@@ -54,18 +44,7 @@ export default function Trending() {
                     <h1 className="text-2xl font-semibold text-gray-900">인기 급상승</h1>
                 </div>
 
-                <div className="flex border-b border-gray-200">
-                    {categories.map(({ label, value }) => (
-                        <CategoryBar
-                            key={value}
-                            category={label}
-                            selected={value === isSelected}
-                            onClick={() => setIsSelected(value)}
-                        />
-                    ))}
-                </div>
-
-                <VideoSummaryList data={videoList} />
+                <VideoSummaryList data={videoList}/>
             </div>
         </div>
     );

--- a/src/services/video.service.ts
+++ b/src/services/video.service.ts
@@ -70,11 +70,10 @@ export const deleteScrap = async (scrapId: number): Promise<void> => {
 };
 
 export const fetchTrendingVideos = async (
-    category: string,
-    maxResults: number
+    maxResults: number = 10
 ): Promise<VideoSummaryItem[]> => {
     const res = await api.get<BaseApiResponse<VideoSummaryItem[]>>(
-        "/trending/category", {params: {categoryType: category, maxResults}}
+        "/trending", {params: {maxResults}}
     );
     return res.data.data;
 };


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #69

---

### 🚀 어떤 기능을 구현했나요?
카테고리별 인기 영상에서 자체 알고리즘 기반 통합 인기 영상으로 변경

### 🔥 어떻게 해결했나요?
- API 엔드포인트 변경: `/trending/category` → `/trending`
- fetchTrendingVideos 파라미터: `(category, maxResults)` → `(maxResults)`
- 카테고리 탭(최신/음악/게임) 및 관련 상태 제거
- CategoryBar 컴포넌트 제거

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- video.service.ts의 fetchTrendingVideos 함수 변경
- Trending 페이지의 단순화된 구조

### 📚 참고 자료, 할 말
- 