### PR TITLE
feat: 영상 비교 페이지 구현 (#73)

### DIFF
--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -1,0 +1,6 @@
+import Compare from "@components/compare";
+
+export default function Page() {
+
+    return <Compare />
+}

--- a/src/components/common/Comment/CommentItem.tsx
+++ b/src/components/common/Comment/CommentItem.tsx
@@ -7,9 +7,9 @@ type Props = Comment & {
 };
 
 const SENTIMENT_LABEL = {
-    POSITIVE: { text: "긍정", color: "bg-blue-100 text-blue-600" },
-    NEGATIVE: { text: "부정", color: "bg-red-100 text-red-600" },
-    OTHER:    { text: "기타", color: "bg-gray-200 text-gray-600" },
+    positive: { text: "긍정", color: "bg-blue-100 text-blue-600" },
+    negative: { text: "부정", color: "bg-red-100 text-red-600" },
+    other:    { text: "기타", color: "bg-gray-200 text-gray-600" },
 } as const;
 
 export default function CommentItem({
@@ -17,9 +17,9 @@ export default function CommentItem({
                                         text,
                                         likeCount,
                                         publishedAt,
-                                        sentiment = "OTHER",
+                                        sentiment = "other",
                                     }: Props) {
-    const badge = SENTIMENT_LABEL[sentiment] ?? SENTIMENT_LABEL.OTHER;
+    const badge = SENTIMENT_LABEL[sentiment] ?? SENTIMENT_LABEL.other;
 
     return (
         <div className="w-full p-4 sm:px-5 sm:py-4 rounded-xl bg-gray-100">

--- a/src/components/common/SentimentBar/SentimentBar.tsx
+++ b/src/components/common/SentimentBar/SentimentBar.tsx
@@ -5,7 +5,7 @@ import SentimentItem from './SentimentItem';
 import {SentimentRatio} from '@/types/video.types';
 import EmptyState from "@components/common/EmptyState";
 
-type SentimentType = 'POSITIVE' | 'NEGATIVE' | 'OTHER';
+type SentimentType = 'positive' | 'negative' | 'other';
 
 interface SentimentBarProps {
     ratio?: SentimentRatio;
@@ -14,19 +14,19 @@ interface SentimentBarProps {
 }
 
 const COLORS = {
-    POSITIVE: {
+    positive: {
         text: 'text-blue-500',
         bg: 'bg-blue-50',
         hoverBg: 'hover:bg-blue-100/90',
         label: '긍정',
     },
-    NEGATIVE: {
+    negative: {
         text: 'text-red-500',
         bg: 'bg-red-50',
         hoverBg: 'hover:bg-red-100/70',
         label: '부정',
     },
-    OTHER: {
+    other: {
         text: 'text-gray-500',
         bg: 'bg-gray-50',
         hoverBg: 'hover:bg-gray-200/70',
@@ -37,22 +37,13 @@ const COLORS = {
 const clampPercent = (value: number) => Math.max(0, Math.min(100, value));
 
 export default function SentimentBar({ratio, size = 'md', onClick}: SentimentBarProps) {
-    const [hoveredKey, setHoveredKey] = useState<string | null>(null);
+    const [hoveredKey, setHoveredKey] = useState<SentimentType | null>(null);
 
-    const handleClick = useCallback((key: string) => {
-        const map: Record<string, SentimentType> = {
-            positive: 'POSITIVE',
-            negative: 'NEGATIVE',
-            other: 'OTHER',
-        };
-        const sentiment = map[key.toLowerCase()];
-        console.log("감정 클릭됨", key, "→", sentiment);
-
-        if (onClick && sentiment) {
+    const handleClick = useCallback((sentiment: SentimentType) => {
+        if (onClick) {
             onClick(sentiment);
         }
     }, [onClick]);
-
 
     const hasValidData =
         ratio &&
@@ -66,9 +57,10 @@ export default function SentimentBar({ratio, size = 'md', onClick}: SentimentBar
         <div className="flex w-full gap-2 items-center">
             <div className="flex items-center w-full overflow-hidden rounded-full">
                 {Object.entries(ratio).map(([key, value]) => {
+                    const sentimentKey = key as SentimentType;
                     const percent = clampPercent(value);
-                    const isHovered = hoveredKey === key;
-                    const colorSet = COLORS[key as keyof typeof COLORS];
+                    const isHovered = hoveredKey === sentimentKey;
+                    const colorSet = COLORS[sentimentKey];
 
                     if (!colorSet) return null;
 
@@ -76,8 +68,8 @@ export default function SentimentBar({ratio, size = 'md', onClick}: SentimentBar
 
                     return (
                         <SentimentItem
-                            key={key}
-                            keyName={key}
+                            key={sentimentKey}
+                            sentiment={sentimentKey}
                             label={label}
                             percent={percent}
                             isHovered={isHovered}

--- a/src/components/common/SentimentBar/SentimentItem.tsx
+++ b/src/components/common/SentimentBar/SentimentItem.tsx
@@ -1,7 +1,7 @@
-import React from "react";
+type SentimentType = 'positive' | 'negative' | 'other';
 
 type SentimentItemProps = {
-    keyName: string;
+    sentiment: SentimentType;
     label: string;
     percent: number;
     isHovered: boolean;
@@ -9,13 +9,13 @@ type SentimentItemProps = {
     bg: string;
     hoverBg: string;
     size: 'sm' | 'md';
-    onClick: (label: string, percent: number) => void;
-    onHover: (key: string | null) => void;
+    onClick: (sentiment: SentimentType) => void;
+    onHover: (sentiment: SentimentType | null) => void;
 };
 
 export default function SentimentItem(props: SentimentItemProps) {
     const {
-        keyName,
+        sentiment,
         label,
         percent,
         isHovered,
@@ -45,8 +45,8 @@ export default function SentimentItem(props: SentimentItemProps) {
                 width: displayWidth,
                 minWidth: shouldShowText ? '3rem' : '0',
             }}
-            onClick={() => onClick(keyName, percent)}
-            onMouseEnter={() => onHover(keyName)}
+            onClick={() => onClick(sentiment)}
+            onMouseEnter={() => onHover(sentiment)}
             onMouseLeave={() => onHover(null)}
         >
             {shouldShowText && `${label} ${percent}%`}

--- a/src/components/common/video-preview/AnalysisPanel.tsx
+++ b/src/components/common/video-preview/AnalysisPanel.tsx
@@ -21,7 +21,7 @@ export default function AnalysisPanel({ analysis, className }: Props) {
 
             <AnalysisItem icon={<FaceSmileIcon className="size-5 stroke-2"/>}>
                 <SentimentBar
-                    ratio={sentimentDistribution ?? {POSITIVE: 0, NEGATIVE: 0, OTHER: 0}}
+                    ratio={sentimentDistribution ?? {positive: 0, negative: 0, other: 0}}
                     size="sm"
                 />
             </AnalysisItem>

--- a/src/components/compare/CompareItem.tsx
+++ b/src/components/compare/CompareItem.tsx
@@ -1,0 +1,59 @@
+import Thumbnail from "@components/common/Thumbnail/Thumbnail";
+import VideoInfo from "@components/common/video-preview/VideoInfo";
+import {VideoResult} from "@/types";
+import AISummary from "@components/common/AISummary";
+import SentimentBar from "@components/common/SentimentBar/SentimentBar";
+import CommentList from "@components/common/Comment/CommentList";
+import LanguageChart from "@components/videos/LanguageChart";
+import CommentTimeChart from "@components/videos/CommentTimeChart";
+import TagList from "@components/common/Tag/TagList";
+import SectionLayout from "@components/videos/SectionLayout";
+
+interface Props {
+    data: VideoResult | null;
+}
+
+export default function CompareItem({data}: Props) {
+    if (!data) {
+        return (
+            <div className="flex-1 min-w-0 flex items-center justify-center bg-gray-100 rounded-lg p-8">
+                <p className="text-gray-500">데이터를 불러올 수 없습니다</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex-1 min-w-0 flex flex-col gap-5">
+            <div className="bg-white rounded-lg overflow-hidden">
+                <Thumbnail src={data.video.thumbnailUrl} />
+                <div className="p-4">
+                    <VideoInfo video={data.video} channel={data.channel} />
+                </div>
+            </div>
+
+            <SectionLayout header="AI 전체 댓글 요약">
+                <AISummary summary={data.analysis.summary} size={'sm'}/>
+            </SectionLayout>
+
+            <SectionLayout header="댓글 감정 비율">
+                <SentimentBar ratio={data.analysis.sentimentDistribution} size={'sm'}/>
+            </SectionLayout>
+
+            <SectionLayout header="좋아요 Top 5">
+                <CommentList comments={data.analysis.topComments} />
+            </SectionLayout>
+
+            <SectionLayout header="언어 비율">
+                <LanguageChart data={data.analysis.languageDistribution} />
+            </SectionLayout>
+
+            <SectionLayout header="댓글 작성 시간대">
+                <CommentTimeChart data={data.analysis.commentHistogram} />
+            </SectionLayout>
+
+            <SectionLayout header="주요 키워드">
+                <TagList tags={data.analysis.keywords} />
+            </SectionLayout>
+        </div>
+    );
+}

--- a/src/components/compare/index.tsx
+++ b/src/components/compare/index.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import {useEffect, useState} from "react";
+import type {VideoResult} from "@/types";
+import {fetchVideoDetail} from "@/services/video.service";
+import CompareItem from "@components/compare/CompareItem";
+
+const VIDEO_IDS = ["SjkeRCZjNIw", "BNcIIzxp9vI", "3FK_9wdUnVo"];
+
+export default function Compare() {
+    const [compareData, setCompareData] = useState<(VideoResult | null)[]>([null, null, null]);
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        const loadAllVideos = async () => {
+            try {
+                const results = await Promise.all(
+                    VIDEO_IDS.map(id => fetchVideoDetail(id).catch((err) => {
+                        console.error(`${id} 로딩 실패:`, err);
+                        return null;
+                    }))
+                );
+                setCompareData(results);
+            } catch (error) {
+                console.error("데이터 로딩 실패:", error);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+
+        loadAllVideos();
+    }, []);
+
+    if (isLoading) {
+        return (
+            <div className="flex items-center justify-center min-h-screen">
+                <div className="text-center">
+                    <div className="animate-spin rounded-full h-16 w-16 border-b-4 border-blue-500 mx-auto mb-4"></div>
+                    <p className="text-gray-600">영상 데이터를 불러오는 중...</p>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="w-full px-4 py-8 max-w-6xl mx-auto">
+            <h1 className="text-2xl font-bold mb-8">📊 영상 비교하기</h1>
+            <div className="flex gap-6 overflow-x-auto">
+                {compareData.map((data, idx) => (
+                    <CompareItem data={data} key={VIDEO_IDS[idx]} />
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/src/components/home/EmotionBar.tsx
+++ b/src/components/home/EmotionBar.tsx
@@ -3,10 +3,10 @@ import {HashtagIcon} from "@heroicons/react/24/outline";
 type EmotionBarProps = {
     positive: number;
     negative: number;
-    etc: number;
+    other: number;
 };
 
-export default function EmotionBar({ positive, negative, etc }: EmotionBarProps) {
+export default function EmotionBar({ positive, negative, other }: EmotionBarProps) {
     return (
         <div className="flex gap-2 items-center">
             <HashtagIcon className="size-6"/>
@@ -25,9 +25,9 @@ export default function EmotionBar({ positive, negative, etc }: EmotionBarProps)
       </span>
                 <span
                     className="text-gray-500 bg-gray-50 px-4 py-2 text-xs truncate"
-                    style={{width: `${etc}%`}}
+                    style={{width: `${other}%`}}
                 >
-        기타 {etc}%
+        기타 {other}%
       </span>
             </div>
         </div>

--- a/src/components/videos/index.tsx
+++ b/src/components/videos/index.tsx
@@ -119,7 +119,7 @@ export default function Detail({videoId}: { videoId: string }) {
                             <LoadingSection message="감정 분석 중..."/>
                         ) : (
                             <SentimentBar
-                                ratio={data.aiAnalysis?.sentimentDistribution ?? {POSITIVE: 0, NEGATIVE: 0, OTHER: 0}}
+                                ratio={data.aiAnalysis?.sentimentDistribution ?? {positive: 0, negative: 0, other: 0}}
                                 onClick={(sentiment) => actions.handleFilterComments({sentiment})}
                             />
                         )}

--- a/src/hooks/useSearchQuery.ts
+++ b/src/hooks/useSearchQuery.ts
@@ -28,9 +28,9 @@ const convertMockToVideoSummaryItem = (mockVideo: typeof MOCK_VIDEOS[0]): VideoS
     analysis: {
         summary: mockVideo.summary || '',
         sentimentDistribution: {
-            POSITIVE: mockVideo.sentiment.positive,
-            NEGATIVE: mockVideo.sentiment.negative,
-            OTHER: mockVideo.sentiment.other,
+            positive: mockVideo.sentiment.positive,
+            negative: mockVideo.sentiment.negative,
+            other: mockVideo.sentiment.other,
         },
         keywords: mockVideo.keywords,
     },

--- a/src/hooks/useVideoDetail.ts
+++ b/src/hooks/useVideoDetail.ts
@@ -95,6 +95,8 @@ export function useVideoDetail(videoId: string): UseVideoDetailReturn {
         ]).then(([analysis, commentsList, ai]) => {
             if (!mounted) return;
 
+            console.log(`[${videoId}] 로딩된 데이터:`, {analysis, commentsList, ai});
+
             if (analysis) setAnalysisInfo(analysis);
             if (commentsList && commentsList.length > 0) {
                 setComments(commentsList);

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -16,7 +16,7 @@ export const fetchFilteredComments = async ({
                                             }: {
     videoId: string;
     q?: string;
-    sentiment?: 'POSITIVE' | 'NEGATIVE' | 'OTHER';
+    sentiment?: 'positive' | 'negative' | 'other';
     keyword?: string;
 }): Promise<Comment[]> => {
     console.log("[API 호출됨]", {videoId, q, sentiment, keyword});

--- a/src/types/video-detail.types.ts
+++ b/src/types/video-detail.types.ts
@@ -31,7 +31,7 @@ export interface VideoDetailState {
 
 export type CommentFilterParams = {
     q?: string;
-    sentiment?: 'POSITIVE' | 'NEGATIVE' | 'OTHER';
+    sentiment?: 'positive' | 'negative' | 'other';
 };
 
 export interface VideoDetailActions {

--- a/src/types/video.types.ts
+++ b/src/types/video.types.ts
@@ -43,7 +43,7 @@ export interface Comment {
     author: string;
     text: string;
     likeCount: number;
-    sentiment: 'POSITIVE' | 'NEGATIVE' | 'OTHER';
+    sentiment: 'positive' | 'negative' | 'other';
     publishedAt: string;
     hasReplies?: boolean;
 }
@@ -54,9 +54,9 @@ export interface LanguageRatio {
 }
 
 export interface SentimentRatio {
-    POSITIVE: number;
-    NEGATIVE: number;
-    OTHER: number;
+    positive: number;
+    negative: number;
+    other: number;
 }
 
 export interface TimestampMention {


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #73
---

### 🚀 어떤 기능을 구현했나요?
- 영상 3개의 AI 분석 결과를 나란히 비교하는 페이지 구현

### 🔥 어떻게 해결했나요?
- `/compare` 페이지에서 3개 영상 ID를 병렬로 호출하여 데이터 로딩
- `CompareItem` 컴포넌트로 각 영상의 AI 분석 정보 렌더링
- Detail 페이지와 동일한 `SectionLayout` 구조 재사용

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 3개 영상 병렬 로딩 로직
- CompareItem 레이아웃 및 반응형 처리

### 📚 참고 자료, 할 말
- 현재는 하드코딩된 3개 영상 ID 사용 중
- 추후 영상 선택 로직 필요 