### PR TITLE
feat: 대댓글(답글) 렌더링 기능 구현 (#75)

### DIFF
--- a/src/components/common/Comment/CommentItem.tsx
+++ b/src/components/common/Comment/CommentItem.tsx
@@ -1,51 +1,144 @@
-import { HandThumbUpIcon } from "@heroicons/react/24/solid";
-import { formatDate, formatNumber } from "@/utils/data-format";
-import { Comment } from "@/types/video.types";
+"use client";
 
-type Props = Comment & {
-    color?: string;
-};
+import {useState} from "react";
+import {HandThumbUpIcon, ChevronDownIcon, ChevronUpIcon} from "@heroicons/react/24/solid";
+import {formatDate, formatNumber} from "@/utils/data-format";
+import {Comment} from "@/types/video.types";
+import ReplyItem from "./ReplyItem";
+import {fetchCommentReplies} from "@/services/video.service";
+
+type Props = Comment;
 
 const SENTIMENT_LABEL = {
-    positive: { text: "긍정", color: "bg-blue-100 text-blue-600" },
-    negative: { text: "부정", color: "bg-red-100 text-red-600" },
-    other:    { text: "기타", color: "bg-gray-200 text-gray-600" },
+    positive: {text: "긍정", color: "bg-blue-100 text-blue-600"},
+    negative: {text: "부정", color: "bg-red-100 text-red-600"},
+    other: {text: "기타", color: "bg-gray-200 text-gray-600"},
 } as const;
 
 export default function CommentItem({
+                                        id,
                                         author,
                                         text,
                                         likeCount,
                                         publishedAt,
                                         sentiment = "other",
+                                        hasReplies = false,
+                                        replies: initialReplies,
                                     }: Props) {
+    const [isRepliesOpen, setIsRepliesOpen] = useState(false);
+    const [replies, setReplies] = useState(initialReplies ?? []);
+    const [isLoadingReplies, setIsLoadingReplies] = useState(false);
+    const [loadError, setLoadError] = useState(false);
+
     const badge = SENTIMENT_LABEL[sentiment] ?? SENTIMENT_LABEL.other;
 
-    return (
-        <div className="w-full p-4 sm:px-5 sm:py-4 rounded-xl bg-gray-100">
-            <div className="flex flex-col gap-2.5">
-                <div className="flex justify-between items-start gap-3">
-                    <div className="flex items-center gap-2 flex-wrap">
-                        <p className="text-sm font-semibold text-gray-800 max-w-[200px] truncate">
-                            {author}
-                        </p>
-                        <p className="text-sm text-gray-400 whitespace-nowrap">
-                            {formatDate(publishedAt, true)}
-                        </p>
-                        <span className={`text-xs px-2 py-[2px] rounded-full font-medium whitespace-nowrap ${badge.color}`}>
-                            {badge.text}
-                        </span>
-                    </div>
-                    <div className="flex gap-1 items-center flex-shrink-0 {/*min-w-[55px]*/}">
-                        <HandThumbUpIcon className="w-4 h-4 text-gray-400" />
-                        <p className="text-sm text-gray-500 whitespace-nowrap">
-                            {formatNumber(likeCount)}
-                        </p>
-                    </div>
-                </div>
+    const handleToggleReplies = async () => {
+        if (isRepliesOpen) {
+            setIsRepliesOpen(false);
+            return;
+        }
 
-                <p className="text-sm text-gray-800 whitespace-pre-wrap break-words">{text}</p>
+        if (replies.length > 0) {
+            setIsRepliesOpen(true);
+            return;
+        }
+
+        setIsLoadingReplies(true);
+        setLoadError(false);
+        try {
+            const fetchedReplies = await fetchCommentReplies(id);
+            setReplies(fetchedReplies);
+            setIsRepliesOpen(true);
+        } catch (error) {
+            console.error("대댓글 로딩 실패:", error);
+            setLoadError(true);
+        } finally {
+            setIsLoadingReplies(false);
+        }
+    };
+
+    return (
+        <div className="w-full">
+            <div className="p-4 sm:px-5 sm:py-4 rounded-xl bg-gray-100">
+                <div className="flex flex-col gap-2.5">
+                    <div className="flex justify-between items-start gap-3">
+                        <div className="flex items-center gap-2 flex-wrap">
+                            <p className="text-sm font-semibold text-gray-800 max-w-[200px] truncate">
+                                {author}
+                            </p>
+                            <p className="text-sm text-gray-400 whitespace-nowrap">
+                                {formatDate(publishedAt, true)}
+                            </p>
+                            <span
+                                className={`text-xs px-2 py-[2px] rounded-full font-medium whitespace-nowrap ${badge.color}`}>
+                                {badge.text}
+                            </span>
+                        </div>
+                        <div className="flex gap-1 items-center flex-shrink-0">
+                            <HandThumbUpIcon className="w-4 h-4 text-gray-400"/>
+                            <p className="text-sm text-gray-500 whitespace-nowrap">
+                                {formatNumber(likeCount)}
+                            </p>
+                        </div>
+                    </div>
+
+                    <p className="text-sm text-gray-800 whitespace-pre-wrap break-words">{text}</p>
+
+                    {hasReplies && (
+                        <button
+                            onClick={handleToggleReplies}
+                            disabled={isLoadingReplies}
+                            className="flex items-center gap-1 text-sm text-gray-600 hover:text-gray-900 font-semibold mt-1 w-fit disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                        >
+                            {isLoadingReplies ? (
+                                <>
+                                    <div
+                                        className="w-4 h-4 border-2 border-gray-600 border-t-transparent rounded-full animate-spin"/>
+                                    답글 로딩 중...
+                                </>
+                            ) : isRepliesOpen ? (
+                                <>
+                                    <ChevronUpIcon className="w-4 h-4"/>
+                                    답글 숨기기
+                                </>
+                            ) : (
+                                <>
+                                    <ChevronDownIcon className="w-4 h-4"/>
+                                    답글 보기
+                                </>
+                            )}
+                        </button>
+                    )}
+
+                    {loadError && (
+                        <p className="text-xs text-gray-500 mt-1">
+                            답글을 불러오는데 실패했습니다. 다시 시도해주세요.
+                        </p>
+                    )}
+                </div>
             </div>
+
+            {hasReplies && isRepliesOpen && !isLoadingReplies && (
+                <div className="ml-3.5 sm:ml-7 mt-2 space-y-2">
+                    {replies.length > 0 ? (
+                        replies.map((reply, index) => (
+                            <div key={reply.id} className="relative pl-5 sm:pl-6">
+                                <div
+                                    className="absolute left-0 top-0 w-3.5 sm:w-5 h-10 border-l-2 border-b-2 border-gray-300 rounded-bl-lg"
+                                />
+                                {index !== replies.length - 1 && (
+                                    <div className="absolute left-0 top-10 bottom-0 w-0.5 bg-gray-300"/>
+                                )}
+                                <ReplyItem {...reply} />
+                            </div>
+                        ))
+                    ) : (
+                        <div className="p-4 text-center text-sm text-gray-500">
+                            답글이 없습니다.
+                        </div>
+                    )}
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/common/Comment/CommentList.tsx
+++ b/src/components/common/Comment/CommentList.tsx
@@ -26,7 +26,7 @@ export default function CommentList({comments}: Props) {
             {hasMore && (
                 <button
                     onClick={loadMore}
-                    className="w-full py-3 mt-2 rounded-lg bg-gray-100 hover:bg-gray-200 transition-colors text-sm text-gray-600 font-medium"
+                    className="w-full py-3 mt-2 rounded-lg bg-gray-50 hover:bg-gray-200 transition-colors text-sm text-gray-600 font-medium"
                 >
                     댓글 더보기
                 </button>

--- a/src/components/common/Comment/CommentSlider.tsx
+++ b/src/components/common/Comment/CommentSlider.tsx
@@ -8,10 +8,9 @@ import NoCommentItem from "@components/common/Comment/NoCommentItem";
 type Props = {
     comments: CommentType[];
     intervalMs?: number;
-    color?: string;
 };
 
-export default function CommentSlider({ comments, intervalMs = 7000, color = "100" }: Props) {
+export default function CommentSlider({ comments, intervalMs = 7000 }: Props) {
     const [index, setIndex] = useState(0);
 
     useEffect(() => {
@@ -28,7 +27,7 @@ export default function CommentSlider({ comments, intervalMs = 7000, color = "10
 
     return (
         <div className="w-full min-w-0 transition-opacity duration-500 ease-in-out">
-            <CommentItem {...comments[index]} color={color} />
+            <CommentItem {...comments[index]} />
         </div>
     );
 }

--- a/src/components/common/Comment/ReplyItem.tsx
+++ b/src/components/common/Comment/ReplyItem.tsx
@@ -1,0 +1,37 @@
+import { HandThumbUpIcon } from "@heroicons/react/24/solid";
+import { formatDate, formatNumber } from "@/utils/data-format";
+import { Reply } from "@/types/video.types";
+
+type Props = Reply;
+
+export default function ReplyItem({
+                                      author,
+                                      text,
+                                      likeCount,
+                                      publishedAt,
+                                  }: Props) {
+    return (
+        <div className="w-full p-3 sm:p-4 rounded-lg bg-gray-50">
+            <div className="flex flex-col gap-2">
+                <div className="flex justify-between items-start gap-3">
+                    <div className="flex items-center gap-2 flex-wrap">
+                        <p className="text-sm font-semibold text-gray-700 max-w-[200px] truncate">
+                            {author}
+                        </p>
+                        <p className="text-xs text-gray-400 whitespace-nowrap">
+                            {formatDate(publishedAt, true)}
+                        </p>
+                    </div>
+                    <div className="flex gap-1 items-center flex-shrink-0">
+                        <HandThumbUpIcon className="w-3.5 h-3.5 text-gray-400" />
+                        <p className="text-xs text-gray-500 whitespace-nowrap">
+                            {formatNumber(likeCount)}
+                        </p>
+                    </div>
+                </div>
+
+                <p className="text-sm text-gray-700 whitespace-pre-wrap break-words">{text}</p>
+            </div>
+        </div>
+    );
+}

--- a/src/services/video.service.ts
+++ b/src/services/video.service.ts
@@ -2,6 +2,7 @@ import api from "@/lib/axios";
 import {BaseApiResponse} from "@/types/common.types";
 import {
     Comment,
+    Reply,
     VideoResult,
     VideoBasicResponse,
     VideoAnalysisResponse,
@@ -9,7 +10,8 @@ import {
     VideoAIResponse,
     VideoBasicInfo,
     VideoAnalysisInfo,
-    VideoAIAnalysis
+    VideoAIAnalysis,
+    CommentRepliesResponse
 } from "@/types/video.types";
 import {VideoSummaryItem} from "@/types/video-preview.types";
 
@@ -31,6 +33,11 @@ export const fetchVideoComments = async (apiVideoId: string): Promise<Comment[]>
 export const fetchVideoAI = async (apiVideoId: string): Promise<VideoAIAnalysis> => {
     const res = await api.get<VideoAIResponse>(`/videos/${apiVideoId}/ai`);
     return res.data.data;
+};
+
+export const fetchCommentReplies = async (apiCommentId: string): Promise<Reply[]> => {
+    const res = await api.get<CommentRepliesResponse>(`/comments/${apiCommentId}/replies`);
+    return res.data.data.replies ?? [];
 };
 
 export const fetchVideoDetail = async (apiVideoId: string): Promise<VideoResult> => {

--- a/src/types/video.types.ts
+++ b/src/types/video.types.ts
@@ -46,6 +46,15 @@ export interface Comment {
     sentiment: 'positive' | 'negative' | 'other';
     publishedAt: string;
     hasReplies?: boolean;
+    replies?: Reply[];
+}
+
+export interface Reply {
+    id: string;
+    author: string;
+    text: string;
+    likeCount: number;
+    publishedAt: string;
 }
 
 export interface LanguageRatio {
@@ -92,3 +101,12 @@ export type VideoBasicResponse = BaseApiResponse<VideoBasicInfo>;
 export type VideoAnalysisResponse = BaseApiResponse<VideoAnalysisInfo>;
 export type VideoCommentsResponse = BaseApiResponse<Comment[]>;
 export type VideoAIResponse = BaseApiResponse<VideoAIAnalysis>;
+
+export interface CommentRepliesResponse {
+    timeStamp: string;
+    message: string;
+    data: {
+        apiCommentId: string;
+        replies: Reply[];
+    };
+}


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #75 

---

### 🚀 어떤 기능을 구현했나요?
- 댓글에 대댓글을 중첩 구조로 표시하는 기능 추가

### 🔥 어떻게 해결했나요?
- `Reply` 타입 정의 및 `fetchCommentReplies` API 연동
- `ReplyItem` 컴포넌트 추가 
- `CommentItem`에 답글 토글 및 둥근 ㄴ자 가지선 스타일 적용

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 기존 `CommentItem` Props 구조 변경 없이 확장되었는지
- 대댓글 로딩/에러 처리가 적절한지

### 📚 참고 자료, 할 말