### PR TITLE
[Feature] 댓글 반응 흐름 차트 추가

### DIFF
--- a/src/components/common/Tag/TagItem.tsx
+++ b/src/components/common/Tag/TagItem.tsx
@@ -18,7 +18,7 @@ export default function TagItem({
 
     const selectedClass =
         size === "md" && isSelected
-            ? "bg-green-100 text-green-700 border-green-300 font-semibold"
+            ? "bg-blue-100 text-blue-700 border-blue-300 font-semibold"
             : "bg-gray-100 text-gray-700 hover:bg-gray-200/80 border-transparent";
 
     return (

--- a/src/components/videos/CommentTimeChart.tsx
+++ b/src/components/videos/CommentTimeChart.tsx
@@ -29,6 +29,11 @@ ChartJS.register(
     Filler
 );
 
+const CHART_COLORS = {
+    border:  'rgba(248, 113, 113, 0.8)',
+    background:  'rgba(248, 113, 113, 0.4)',
+} as const;
+
 interface Props {
     data?: HourlyCommentCount[];
 }
@@ -45,8 +50,8 @@ export default function CommentTimeChart({ data }: Props) {
             {
                 label: '댓글 수',
                 data: hasValidData ? data.map((d) => d.count) : [],
-                borderColor: 'rgba(255, 99, 132, 1)',
-                backgroundColor: 'rgba(255, 99, 132, 0.3)',
+                borderColor: CHART_COLORS.border,
+                backgroundColor: CHART_COLORS.background,
                 fill: true,
                 tension: 0.4,
             },

--- a/src/components/videos/LanguageChart.tsx
+++ b/src/components/videos/LanguageChart.tsx
@@ -15,8 +15,18 @@ import EmptyState from "@components/common/EmptyState";
 ChartJS.register(ArcElement, Tooltip, Legend);
 
 const COLORS = [
-    '#FF6384', '#FF9F40', '#FFCD56', '#4BC0C0', '#36A2EB',
-];
+    'rgba(248, 113, 113, 0.7)',  // red-400
+    'rgba(251, 146, 60, 0.7)',   // orange-400
+    'rgba(74, 222, 128, 0.7)',   // green-400
+    'rgba(96, 165, 250, 0.7)',   // blue-400
+    'rgba(167, 139, 250, 0.7)',  // violet-400
+    'rgba(148, 163, 184, 0.7)',  // slate-400
+    'rgba(251, 191, 36, 0.7)',   // amber-400
+    'rgba(34, 211, 238, 0.7)',   // cyan-400
+    'rgba(56, 189, 248, 0.7)',   // sky-400
+    'rgba(244, 114, 182, 0.7)',  // pink-400
+] as const;
+
 
 interface LanguageChartProps {
     data?: LanguageRatio[];

--- a/src/components/videos/SentimentFlowChart.tsx
+++ b/src/components/videos/SentimentFlowChart.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { Line } from 'react-chartjs-2';
+import {
+    Chart as ChartJS,
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Filler,
+    Tooltip,
+    Legend,
+    ChartOptions,
+} from 'chart.js';
+import {SentimentFlowData} from "@/types";
+
+ChartJS.register(
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    LineElement,
+    Filler,
+    Tooltip,
+    Legend
+);
+
+const CHART_COLORS = {
+    positive: {
+        background: 'rgba(239, 246, 255, 1)',
+        border: 'rgba(59, 130, 246, 0.6)',
+    },
+    negative: {
+        background: 'rgba(254, 242, 242, 1)',
+        border: 'rgba(239, 68, 68, 0.6)',
+    },
+    other: {
+        background: 'rgba(249, 250, 251, 1)',
+        border: 'rgba(107, 114, 128, 0.6)',
+    },
+} as const;
+
+const CHART_CONFIG = {
+    borderWidth: 1.3,
+    tension: 0.4,
+    height: 300,
+    minY: 0,
+    maxY: 100,
+} as const;
+
+interface SentimentFlowChartProps {
+    data?: SentimentFlowData[];
+}
+
+const MOCK_DATA: SentimentFlowData[] = [
+    { date: "2024-01-15", positive: 0.67, negative: 0.22, other: 0.11 },
+    { date: "2024-01-16", positive: 0.72, negative: 0.19, other: 0.09 },
+    { date: "2024-01-17", positive: 0.65, negative: 0.25, other: 0.10 },
+    { date: "2024-01-18", positive: 0.70, negative: 0.20, other: 0.10 },
+    { date: "2024-01-19", positive: 0.68, negative: 0.22, other: 0.10 },
+    { date: "2024-01-20", positive: 0.75, negative: 0.15, other: 0.10 },
+    { date: "2024-01-21", positive: 0.80, negative: 0.12, other: 0.08 },
+];
+
+export default function SentimentFlowChart({ data = MOCK_DATA }: SentimentFlowChartProps) {
+    const convertToPercentage = (values: number[]) => values.map(v => v * 100);
+
+    const labels = data.map(item => item.date);
+
+    const positiveData = convertToPercentage(data.map(item => item.positive));
+    const negativeData = convertToPercentage(data.map(item => item.negative));
+    const otherData = convertToPercentage(data.map(item => item.other));
+
+    const chartData = {
+        labels,
+        datasets: [
+            {
+                label: '긍정',
+                data: positiveData,
+                backgroundColor: CHART_COLORS.positive.background,
+                borderColor: CHART_COLORS.positive.border,
+                borderWidth: CHART_CONFIG.borderWidth,
+                fill: true,
+                tension: CHART_CONFIG.tension,
+            },
+            {
+                label: '부정',
+                data: negativeData,
+                backgroundColor: CHART_COLORS.negative.background,
+                borderColor: CHART_COLORS.negative.border,
+                borderWidth: CHART_CONFIG.borderWidth,
+                fill: true,
+                tension: CHART_CONFIG.tension,
+            },
+            {
+                label: '기타',
+                data: otherData,
+                backgroundColor: CHART_COLORS.other.background,
+                borderColor: CHART_COLORS.other.border,
+                borderWidth: CHART_CONFIG.borderWidth,
+                fill: true,
+                tension: CHART_CONFIG.tension,
+            },
+        ],
+    };
+
+    const options: ChartOptions<'line'> = {
+        responsive: true,
+        maintainAspectRatio: false,
+        interaction: {
+            mode: 'index',
+            intersect: false,
+        },
+        scales: {
+            x: {
+                stacked: true,
+                grid: {
+                    display: false,
+                },
+            },
+            y: {
+                stacked: true,
+                min: CHART_CONFIG.minY,
+                max: CHART_CONFIG.maxY,
+                ticks: {
+                    stepSize: 20,
+                    callback: (value) => `${value}%`,
+                },
+                grid: {
+                    color: 'rgba(0, 0, 0, 0.05)',
+                },
+            },
+        },
+        plugins: {
+            legend: {
+                position: 'top',
+                labels: {
+                    usePointStyle: true,
+                    padding: 15,
+                },
+            },
+            tooltip: {
+                callbacks: {
+                    label: (context) => {
+                        const label = context.dataset.label || '';
+                        const value = context.parsed.y.toFixed(1);
+                        return `${label}: ${value}%`;
+                    },
+                },
+            },
+        },
+    };
+
+    return (
+        <div className="w-full" style={{ height: `${CHART_CONFIG.height}px` }}>
+            <Line data={chartData} options={options} />
+        </div>
+    );
+}

--- a/src/components/videos/index.tsx
+++ b/src/components/videos/index.tsx
@@ -12,6 +12,7 @@ import WarningBanner from "@components/videos/WarningBanner";
 import LoadingSection from "@components/common/LoadingSection";
 import {useVideoDetail} from "@/hooks/useVideoDetail";
 import {useMemo} from "react";
+import SentimentFlowChart from "@components/videos/SentimentFlowChart";
 
 export default function Detail({videoId}: { videoId: string }) {
     const {data, filtered, state, actions, playerRef} = useVideoDetail(videoId);
@@ -148,6 +149,14 @@ export default function Detail({videoId}: { videoId: string }) {
                                 tags={timestampTags}
                                 onTagClick={actions.handleSeek}
                             />
+                        )}
+                    </SectionLayout>
+
+                    <SectionLayout header="댓글 반응 흐름 분석" >
+                        {state.isLoading.analysis ? (
+                            <LoadingSection message="댓글 반응 흐름 분석 분석 중..."/>
+                        ) : (
+                            <SentimentFlowChart />
                         )}
                     </SectionLayout>
 

--- a/src/types/video.types.ts
+++ b/src/types/video.types.ts
@@ -78,6 +78,13 @@ export interface HourlyCommentCount {
     count: number;
 }
 
+export interface SentimentFlowData {
+    date: string;
+    positive: number;
+    negative: number;
+    other: number;
+}
+
 export interface VideoBasicInfo {
     video: VideoDetail;
     channel: Channel;


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #80

---

### 🚀 어떤 기능을 구현했나요?
- 댓글 반응 흐름 분석 차트 추가 (100% 누적 영역 차트)
- 전체 차트 컴포넌트 색상 시스템 통일

### 🔥 어떻게 해결했나요?
- Chart.js의 Line 차트 + fill + stacked 옵션으로 100% 누적 영역 차트 구현
- SentimentFlowData 타입 정의 및 목데이터로 UI 먼저 구현
- 모든 차트를 400 레벨 톤으로 색상 통일
- 하드코딩된 색상/설정값을 상수로 관리하도록 리팩토링

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- SentimentFlowChart의 색상 및 레이아웃 (긍정-부정-기타 순서)
- 차트 색상 팔레트가 전체적으로 통일감 있는지

### 📚 참고 자료, 할 말
- 백엔드 API 완성되면 data props 연결만 하면 됨
- y축은 stepSize 20으로 고정 (가독성 위해)