### PR TITLE
[Feature] 동영상/쇼츠 검색 추가 및 무한 스크롤 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react": "^19.0.0",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",
+    "react-intersection-observer": "^10.0.0",
     "react-youtube": "^10.1.0",
     "swr": "^2.3.6"
   },

--- a/src/components/common/video-preview/AnalysisPanel.tsx
+++ b/src/components/common/video-preview/AnalysisPanel.tsx
@@ -6,12 +6,14 @@ import TagList from "@components/common/Tag/TagList";
 import {AnalysisSummaryOnly} from "@/types/video-preview.types";
 
 interface Props {
-    analysis: AnalysisSummaryOnly;
+    analysis: AnalysisSummaryOnly | null;
     className?: string;
 }
 
-export default function AnalysisPanel({ analysis, className }: Props) {
-    const { summary, sentimentDistribution, keywords } = analysis;
+export default function AnalysisPanel({analysis, className}: Props) {
+    const summary = analysis?.summary ?? null;
+    const sentimentDistribution = analysis?.sentimentDistribution ?? {positive: 0, negative: 0, other: 0};
+    const keywords = analysis?.keywords ?? [];
 
     return (
         <div className={`flex flex-col gap-2 ${className ?? 'w-full'}`}>
@@ -21,13 +23,13 @@ export default function AnalysisPanel({ analysis, className }: Props) {
 
             <AnalysisItem icon={<FaceSmileIcon className="size-5 stroke-2"/>}>
                 <SentimentBar
-                    ratio={sentimentDistribution ?? {positive: 0, negative: 0, other: 0}}
+                    ratio={sentimentDistribution}
                     size="sm"
                 />
             </AnalysisItem>
 
             <AnalysisItem icon={<HashtagIcon className="size-5 stroke-2"/>}>
-                <TagList tags={keywords ?? []} size="sm"/>
+                <TagList tags={keywords} size="sm"/>
             </AnalysisItem>
         </div>
     );

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -1,13 +1,12 @@
 'use client';
 
-import { useSearchParams } from "next/navigation";
+import {useSearchParams} from "next/navigation";
 import SearchTabs from "@components/search/tabs/SearchTabs";
 import AllTab from "@components/search/tabs/AllTab";
 import VideoTab from "@components/search/tabs/VideoTab";
 import ShortsTab from "@components/search/tabs/ShortsTab";
 import ChannelTab from "@components/search/tabs/ChannelTab";
-import LoadingSection from "@components/common/LoadingSection";
-import { useSearchQuery } from "@/hooks/useSearchQuery";
+import {useSearchQuery} from "@/hooks/useSearchQuery";
 
 type TabType = 'all' | 'video' | 'shorts' | 'channel';
 
@@ -16,21 +15,22 @@ export default function SearchContent() {
     const query = searchParams.get("q");
     const activeTab = (searchParams.get("tab") as TabType) || 'all';
 
-    const { channels, videos, shorts, searchType, loading } = useSearchQuery(query, activeTab);
-
-    if (searchType === "URL") {
-        return (
-            <div className="max-w-screen-xl mx-auto px-4 py-20 text-center">
-                <LoadingSection message="영상 페이지로 이동 중..." />
-            </div>
-        );
-    }
+    const {
+        channels,
+        videos,
+        shorts,
+        loading,
+        videoNextPageToken,
+        videosHasMore,
+        shortsNextPageToken,
+        shortsHasMore,
+    } = useSearchQuery(query, activeTab);
 
     return (
         <div className="max-w-screen-xl mx-auto px-4 sm:px-6 lg:px-8">
             <h2 className="text-2xl font-bold mb-6">&apos;{query}&apos; 검색 결과</h2>
 
-            <SearchTabs />
+            <SearchTabs/>
 
             {activeTab === 'all' && (
                 <AllTab
@@ -43,15 +43,25 @@ export default function SearchContent() {
             )}
 
             {activeTab === 'video' && (
-                <VideoTab videos={videos} loading={loading.videos} />
+                <VideoTab
+                    videos={videos}
+                    loading={loading.videos}
+                    initialNextPageToken={videoNextPageToken}
+                    initialHasMore={videosHasMore}
+                />
             )}
 
             {activeTab === 'shorts' && (
-                <ShortsTab shorts={shorts} loading={loading.shorts} />
+                <ShortsTab
+                    shorts={shorts}
+                    loading={loading.shorts}
+                    initialNextPageToken={shortsNextPageToken}
+                    initialHasMore={shortsHasMore}
+                />
             )}
 
             {activeTab === 'channel' && (
-                <ChannelTab channels={channels} loading={loading.channels} />
+                <ChannelTab channels={channels} loading={loading.channels}/>
             )}
         </div>
     );

--- a/src/components/search/tabs/ShortsTab.tsx
+++ b/src/components/search/tabs/ShortsTab.tsx
@@ -1,26 +1,53 @@
+'use client';
+
 import ShortsPreview from "@components/common/video-preview/ShortsPreview";
 import LoadingSection from "@components/common/LoadingSection";
-import type { VideoSummaryItem } from "@/types";
+import {searchShorts} from "@/services/search.service";
+import {useInfiniteScroll} from "@/hooks/useInfiniteScroll";
+import type {VideoSummaryItem} from "@/types";
 
 interface Props {
     shorts: VideoSummaryItem[];
     loading: boolean;
+    initialNextPageToken: string | null;
+    initialHasMore: boolean;
 }
 
-export default function ShortsTab({ shorts, loading }: Props) {
+export default function ShortsTab({shorts, loading, initialNextPageToken, initialHasMore}: Props) {
+    const {data, hasMore, isLoadingMore, scrollRef} = useInfiniteScroll({
+        initialData: shorts,
+        initialNextPageToken,
+        initialHasMore,
+        searchFunction: searchShorts,
+    });
+
     if (loading) {
-        return <LoadingSection message="Shorts 검색 중..." />;
+        return <LoadingSection message="Shorts 검색 중..."/>;
     }
 
-    if (shorts.length === 0) {
+    if (!data || data.length === 0) {
         return <p className="text-gray-500">검색 결과가 없습니다.</p>;
     }
 
     return (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
-            {shorts.map((video) => (
-                <ShortsPreview key={video.video.id} data={video} />
-            ))}
+        <div className="flex flex-col gap-5">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-5">
+                {data.map((video) => (
+                    <ShortsPreview key={video.video.id} data={video}/>
+                ))}
+            </div>
+
+            {hasMore && (
+                <div ref={scrollRef} className="py-4 text-center">
+                    {isLoadingMore && (
+                        <div className="flex items-center justify-center gap-2">
+                            <div
+                                className="w-8 h-8 border-4 border-gray-300 border-t-blue-500 rounded-full animate-spin"/>
+                            <span className="text-gray-600">더 많은 Shorts를 불러오는 중...</span>
+                        </div>
+                    )}
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/search/tabs/VideoTab.tsx
+++ b/src/components/search/tabs/VideoTab.tsx
@@ -1,26 +1,51 @@
+'use client';
+
 import VideoPreview from "@components/common/video-preview/VideoPreview";
 import LoadingSection from "@components/common/LoadingSection";
-import type { VideoSummaryItem } from "@/types/video-preview.types";
+import {searchVideos} from "@/services/search.service";
+import type {VideoSummaryItem} from "@/types/video-preview.types";
+import {useInfiniteScroll} from "@/hooks/useInfiniteScroll";
 
 interface Props {
     videos: VideoSummaryItem[];
     loading: boolean;
+    initialNextPageToken: string | null;
+    initialHasMore: boolean;
 }
 
-export default function VideoTab({ videos, loading }: Props) {
+export default function VideoTab({videos, loading, initialNextPageToken, initialHasMore}: Props) {
+    const {data, hasMore, isLoadingMore, scrollRef} = useInfiniteScroll({
+        initialData: videos,
+        initialNextPageToken,
+        initialHasMore,
+        searchFunction: searchVideos,
+    });
+
     if (loading) {
-        return <LoadingSection message="동영상 검색 중..." />;
+        return <LoadingSection message="동영상 검색 중..."/>;
     }
 
-    if (videos.length === 0) {
+    if (!data || data.length === 0) {
         return <p className="text-gray-500">검색 결과가 없습니다.</p>;
     }
 
     return (
         <div className="flex flex-col w-full gap-5">
-            {videos.map((video) => (
-                <VideoPreview key={video.video.id} data={video} />
+            {data.map((video) => (
+                <VideoPreview key={video.video.id} data={video}/>
             ))}
+
+            {hasMore && (
+                <div ref={scrollRef} className="py-4 text-center">
+                    {isLoadingMore && (
+                        <div className="flex items-center justify-center gap-2">
+                            <div
+                                className="w-8 h-8 border-4 border-gray-300 border-t-blue-500 rounded-full animate-spin"/>
+                            <span className="text-gray-600">더 많은 동영상을 불러오는 중...</span>
+                        </div>
+                    )}
+                </div>
+            )}
         </div>
     );
 }

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -1,0 +1,65 @@
+import {useState, useEffect} from "react";
+import {useSearchParams} from "next/navigation";
+import {useInView} from "react-intersection-observer";
+import type {VideoSummaryItem} from "@/types/video-preview.types";
+
+type SearchFunction = (query: string, pageToken?: string) => Promise<{
+    results: VideoSummaryItem[];
+    nextPageToken: string | null;
+    hasMore: boolean;
+}>;
+
+interface UseInfiniteScrollProps {
+    initialData: VideoSummaryItem[];
+    initialNextPageToken: string | null;
+    initialHasMore: boolean;
+    searchFunction: SearchFunction;
+}
+
+export function useInfiniteScroll({
+                                      initialData,
+                                      initialNextPageToken,
+                                      initialHasMore,
+                                      searchFunction,
+                                  }: UseInfiniteScrollProps) {
+    const searchParams = useSearchParams();
+    const query = searchParams.get("q");
+
+    const [data, setData] = useState(initialData || []);
+    const [nextPageToken, setNextPageToken] = useState(initialNextPageToken);
+    const [hasMore, setHasMore] = useState(initialHasMore);
+    const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+    const {ref, inView} = useInView({threshold: 0});
+
+    // 초기 데이터 업데이트
+    useEffect(() => {
+        setData(initialData || []);
+        setNextPageToken(initialNextPageToken);
+        setHasMore(initialHasMore);
+    }, [initialData, initialNextPageToken, initialHasMore]);
+
+    // 무한 스크롤 트리거
+    useEffect(() => {
+        if (!inView || !hasMore || isLoadingMore || !query || !nextPageToken) return;
+
+        const loadMore = async () => {
+            setIsLoadingMore(true);
+            try {
+                const result = await searchFunction(query, nextPageToken);
+                setData((prev) => [...prev, ...result.results]);
+                setNextPageToken(result.nextPageToken);
+                setHasMore(result.hasMore);
+            } catch (error) {
+                console.error("다음 페이지 로드 실패:", error);
+                setHasMore(false);
+            } finally {
+                setIsLoadingMore(false);
+            }
+        };
+
+        loadMore();
+    }, [inView, hasMore, isLoadingMore, query, nextPageToken, searchFunction]);
+
+    return {data, hasMore, isLoadingMore, scrollRef: ref};
+}

--- a/src/hooks/useSearchQuery.ts
+++ b/src/hooks/useSearchQuery.ts
@@ -1,180 +1,190 @@
-import {useState, useEffect, useMemo} from "react";
+import {useState, useEffect} from "react";
 import {useRouter} from "next/navigation";
-import {searchByQuery} from "@/services/search.service";
-import {VideoSummaryItem, ChannelSearchResult} from "@/types";
-import {MOCK_VIDEOS} from "@components/search/mock";
+import {searchChannels, searchVideos, searchShorts} from "@/services/search.service";
+import type {VideoSummaryItem, ChannelSearchResult} from "@/types";
 
 type TabType = 'all' | 'video' | 'shorts' | 'channel';
 
-const convertMockToVideoSummaryItem = (mockVideo: typeof MOCK_VIDEOS[0]): VideoSummaryItem => ({
-    video: {
-        id: mockVideo.id,
-        title: mockVideo.title,
-        description: '',
-        publishedAt: mockVideo.publishedAt,
-        thumbnailUrl: mockVideo.thumbnailUrl,
-        viewCount: mockVideo.viewCount,
-        likeCount: mockVideo.likeCount,
-        commentCount: mockVideo.commentCount,
-        scrapId: null,
-    },
-    channel: {
-        id: `channel_${mockVideo.id}`,
-        title: mockVideo.channelName,
-        thumbnailUrl: mockVideo.thumbnailUrl,
-        subscriberCount: 100000,
-        favoriteChannelId: null,
-    },
-    analysis: {
-        summary: mockVideo.summary || '',
-        sentimentDistribution: {
-            positive: mockVideo.sentiment.positive,
-            negative: mockVideo.sentiment.negative,
-            other: mockVideo.sentiment.other,
-        },
-        keywords: mockVideo.keywords,
-    },
-});
+interface SearchState {
+    channels: ChannelSearchResult[] | null;
+    videos: VideoSummaryItem[];
+    shorts: VideoSummaryItem[];
+    loading: {
+        channels: boolean;
+        videos: boolean;
+        shorts: boolean;
+    };
+    videoPagination: {
+        nextPageToken: string | null;
+        hasMore: boolean;
+    };
+    shortsPagination: {
+        nextPageToken: string | null;
+        hasMore: boolean;
+    };
+}
+
+const initialState: SearchState = {
+    channels: null,
+    videos: [],
+    shorts: [],
+    loading: {channels: false, videos: false, shorts: false},
+    videoPagination: {nextPageToken: null, hasMore: false},
+    shortsPagination: {nextPageToken: null, hasMore: false},
+};
 
 export function useSearchQuery(query: string | null, activeTab: TabType) {
     const router = useRouter();
-    const [channels, setChannels] = useState<ChannelSearchResult[] | null>(null);
-    const [videos, setVideos] = useState<VideoSummaryItem[]>([]);
-    const [shorts, setShorts] = useState<VideoSummaryItem[]>([]);
-    const [searchType, setSearchType] = useState<string>("");
-    const [loading, setLoading] = useState({
-        channels: false,
-        videos: false,
-        shorts: false,
-    });
-
-    const mockVideos = useMemo(() => MOCK_VIDEOS.map(convertMockToVideoSummaryItem), []);
-    const topThreeVideos = useMemo(() => mockVideos.slice(0, 3), [mockVideos]);
-    const topFourShorts = useMemo(() => mockVideos.slice(0, 4), [mockVideos]);
+    const [state, setState] = useState<SearchState>(initialState);
 
     useEffect(() => {
-        if (!query || activeTab !== 'all') return;
+        if (!query) return;
 
-        let mounted = true;
-        setLoading({channels: true, videos: true, shorts: true});
+        const fetchData = async () => {
+            // 초기화
+            setState(initialState);
 
-        console.log('🔵 [통합 탭] 검색 시작:', query);
+            if (activeTab === 'all') {
+                // 통합 탭: 모든 데이터 병렬 로딩
+                setState((prev) => ({
+                    ...prev,
+                    loading: {channels: true, videos: true, shorts: true},
+                }));
 
-        searchByQuery(query)
-            .then((result) => {
-                if (!mounted) return;
-                console.log('✅ [통합 탭] 백엔드 응답:', result);
-                setSearchType(result.searchType);
+                console.log('🔍 [All Tab] 검색 시작:', query);
 
-                if (result.searchType === "URL") {
-                    const apiVideoId = result.results?.[0]?.apiVideoId;
+                const [channelResult, videoResult, shortsResult] = await Promise.allSettled([
+                    searchChannels(query),
+                    searchVideos(query),
+                    searchShorts(query),
+                ]);
 
-                    if (apiVideoId) {
-                        console.log('✅ [통합 탭] URL 검색 - apiVideoId:', apiVideoId);
-                        console.log('🚀 [통합 탭] 리다이렉트:', `/videos/${apiVideoId}`);
-                        router.replace(`/videos/${apiVideoId}`);
+                console.log('📦 [All Tab] 채널 결과:', channelResult);
+                console.log('📦 [All Tab] 동영상 결과:', videoResult);
+                console.log('📦 [All Tab] 쇼츠 결과:', shortsResult);
+
+                setState((prev) => {
+                    const newState = {...prev, loading: {channels: false, videos: false, shorts: false}};
+
+                    // 채널 검색
+                    if (channelResult.status === 'fulfilled') {
+                        newState.channels = channelResult.value;  // 배열 직접 저장
+                        console.log('✅ [All Tab] 채널 설정:', newState.channels.length);
                     } else {
-                        console.error('❌ [통합 탭] apiVideoId 없음:', result);
+                        console.error('❌ [All Tab] 채널 검색 실패:', channelResult.reason);
                     }
-                } else if (result.searchType === "CHANNEL") {
-                    console.log('✅ [통합 탭] 채널 검색 - 결과 수:', result.results.length);
-                    setChannels(result.results);
+
+                    // 동영상
+                    if (videoResult.status === 'fulfilled') {
+                        newState.videos = videoResult.value.results;  // slice 제거 - 백엔드가 이미 적절한 개수로 보냄
+                        newState.videoPagination = {
+                            nextPageToken: videoResult.value.nextPageToken,
+                            hasMore: videoResult.value.hasMore,
+                        };
+                        console.log('✅ [All Tab] 동영상 설정:', newState.videos.length);
+                    } else {
+                        console.error('❌ [All Tab] 동영상 검색 실패:', videoResult.reason);
+                    }
+
+                    // 쇼츠
+                    if (shortsResult.status === 'fulfilled') {
+                        newState.shorts = shortsResult.value.results;  // slice 제거 - 백엔드가 이미 적절한 개수로 보냄
+                        newState.shortsPagination = {
+                            nextPageToken: shortsResult.value.nextPageToken,
+                            hasMore: shortsResult.value.hasMore,
+                        };
+                        console.log('✅ [All Tab] 쇼츠 설정:', newState.shorts.length);
+                    } else {
+                        console.error('❌ [All Tab] 쇼츠 검색 실패:', shortsResult.reason);
+                    }
+
+                    return newState;
+                });
+            } else if (activeTab === 'video') {
+                // 동영상 탭
+                setState((prev) => ({...prev, loading: {...prev.loading, videos: true}}));
+
+                console.log('🔍 [Video Tab] 검색 시작:', query);
+
+                try {
+                    const result = await searchVideos(query);
+                    console.log('✅ [Video Tab] API 응답:', result);
+
+                    setState((prev) => ({
+                        ...prev,
+                        videos: result.results,
+                        videoPagination: {
+                            nextPageToken: result.nextPageToken,
+                            hasMore: result.hasMore,
+                        },
+                        loading: {...prev.loading, videos: false},
+                    }));
+
+                    console.log('✅ [Video Tab] 동영상 설정 완료:', result.results.length, '개');
+                } catch (error) {
+                    console.error("❌ [Video Tab] 동영상 검색 실패:", error);
+                    setState((prev) => ({...prev, loading: {...prev.loading, videos: false}}));
                 }
-            })
-            .catch((error) => {
-                console.error("❌ [통합 탭] 검색 실패:", error);
-            })
-            .finally(() => {
-                if (!mounted) return;
-                setLoading((prev) => ({...prev, channels: false}));
-            });
+            } else if (activeTab === 'shorts') {
+                // 쇼츠 탭
+                setState((prev) => ({...prev, loading: {...prev.loading, shorts: true}}));
 
-        const videoTimer = window.setTimeout(() => {
-            if (!mounted) return;
-            setVideos(topThreeVideos);
-            setLoading((prev) => ({...prev, videos: false}));
-        }, 300);
+                console.log('🔍 [Shorts Tab] 검색 시작:', query);
 
-        const shortsTimer = window.setTimeout(() => {
-            if (!mounted) return;
-            setShorts(topFourShorts);
-            setLoading((prev) => ({...prev, shorts: false}));
-        }, 500);
+                try {
+                    const result = await searchShorts(query);
+                    console.log('✅ [Shorts Tab] API 응답:', result);
 
-        return () => {
-            mounted = false;
-            clearTimeout(videoTimer);
-            clearTimeout(shortsTimer);
-        };
-    }, [query, activeTab, router, topThreeVideos, topFourShorts]);
+                    setState((prev) => ({
+                        ...prev,
+                        shorts: result.results,
+                        shortsPagination: {
+                            nextPageToken: result.nextPageToken,
+                            hasMore: result.hasMore,
+                        },
+                        loading: {...prev.loading, shorts: false},
+                    }));
 
-    useEffect(() => {
-        if (!query || activeTab !== 'video') return;
-
-        let mounted = true;
-        setLoading({channels: false, videos: true, shorts: false});
-
-        const timer = window.setTimeout(() => {
-            if (!mounted) return;
-            setVideos(mockVideos);
-            setLoading((prev) => ({...prev, videos: false}));
-        }, 300);
-
-        return () => {
-            mounted = false;
-            clearTimeout(timer);
-        };
-    }, [query, activeTab, mockVideos]);
-
-    useEffect(() => {
-        if (!query || activeTab !== 'shorts') return;
-
-        let mounted = true;
-        setLoading({channels: false, videos: false, shorts: true});
-
-        const timer = window.setTimeout(() => {
-            if (!mounted) return;
-            setShorts(mockVideos);
-            setLoading((prev) => ({...prev, shorts: false}));
-        }, 300);
-
-        return () => {
-            mounted = false;
-            clearTimeout(timer);
-        };
-    }, [query, activeTab, mockVideos]);
-
-    useEffect(() => {
-        if (!query || activeTab !== 'channel') return;
-
-        let mounted = true;
-        setLoading({channels: true, videos: false, shorts: false});
-
-        searchByQuery(query)
-            .then((result) => {
-                if (!mounted) return;
-                if (result.searchType === "CHANNEL") {
-                    setChannels(result.results);
+                    console.log('✅ [Shorts Tab] 쇼츠 설정 완료:', result.results.length, '개');
+                } catch (error) {
+                    console.error("❌ [Shorts Tab] 쇼츠 검색 실패:", error);
+                    setState((prev) => ({...prev, loading: {...prev.loading, shorts: false}}));
                 }
-            })
-            .catch((error) => {
-                console.error("❌ [채널 탭] 검색 실패:", error);
-            })
-            .finally(() => {
-                if (!mounted) return;
-                setLoading((prev) => ({...prev, channels: false}));
-            });
+            } else if (activeTab === 'channel') {
+                // 채널 탭
+                setState((prev) => ({...prev, loading: {...prev.loading, channels: true}}));
 
-        return () => {
-            mounted = false;
+                console.log('🔍 [Channel Tab] 검색 시작:', query);
+
+                try {
+                    const result = await searchChannels(query);
+                    console.log('✅ [Channel Tab] API 응답:', result);
+
+                    setState((prev) => ({
+                        ...prev,
+                        channels: result,  // 배열 직접 저장
+                        loading: {...prev.loading, channels: false},
+                    }));
+
+                    console.log('✅ [Channel Tab] 채널 설정 완료:', result.length, '개');
+                } catch (error) {
+                    console.error("❌ [Channel Tab] 채널 검색 실패:", error);
+                    setState((prev) => ({...prev, loading: {...prev.loading, channels: false}}));
+                }
+            }
         };
-    }, [query, activeTab]);
+
+        fetchData();
+    }, [query, activeTab, router]);
 
     return {
-        channels,
-        videos,
-        shorts,
-        searchType,
-        loading,
+        channels: state.channels,
+        videos: state.videos,
+        shorts: state.shorts,
+        loading: state.loading,
+        videoNextPageToken: state.videoPagination.nextPageToken,
+        videosHasMore: state.videoPagination.hasMore,
+        shortsNextPageToken: state.shortsPagination.nextPageToken,
+        shortsHasMore: state.shortsPagination.hasMore,
     };
 }

--- a/src/services/main.service.ts
+++ b/src/services/main.service.ts
@@ -1,8 +1,9 @@
 import {FavoriteChannelData} from '@/types/main.types';
 import {VideoSummaryItem} from '@/types/video-preview.types';
 import {ChannelSearchResult, FavoriteChannel} from '@/types/channel.types';
+import {getApiBaseUrl} from '@/lib/url';
 
-const API_BASE = 'https://knu-sosuso.com/api/main';
+const API_BASE = `${getApiBaseUrl()}/api/main`;
 
 async function fetchNoStore(input: RequestInfo, init?: RequestInit) {
     return fetch(input, {credentials: 'include', cache: 'no-store', ...init});

--- a/src/services/search.service.ts
+++ b/src/services/search.service.ts
@@ -1,9 +1,40 @@
 import api from "@/lib/axios";
 import type {Comment} from "@/types/video.types";
+import type {VideoSearchResponse, ShortsSearchResponse} from "@/types/search.types";
+import type {ChannelSearchResult} from "@/types/channel.types";
 
-export const searchByQuery = async (query: string) => {
-    const res = await api.get("/search", {
+/**
+ * 채널 검색
+ */
+export const searchChannels = async (query: string): Promise<ChannelSearchResult[]> => {
+    const res = await api.get("/search/channels", {
         params: {query},
+    });
+    return res.data.data;
+};
+
+/**
+ * 동영상 검색 (쇼츠 제외)
+ */
+export const searchVideos = async (query: string, pageToken?: string): Promise<VideoSearchResponse> => {
+    const res = await api.get("/search/videos", {
+        params: {
+            query,
+            ...(pageToken && {pageToken}),
+        },
+    });
+    return res.data.data;
+};
+
+/**
+ * 쇼츠 검색
+ */
+export const searchShorts = async (query: string, pageToken?: string): Promise<ShortsSearchResponse> => {
+    const res = await api.get("/search/shorts", {
+        params: {
+            query,
+            ...(pageToken && {pageToken}),
+        },
     });
     return res.data.data;
 };

--- a/src/types/search.types.ts
+++ b/src/types/search.types.ts
@@ -1,13 +1,15 @@
-import {ChannelSearchResult} from "@/types/channel.types";
+import {VideoSummaryItem} from "@/types/video-preview.types";
 
-type UrlSearchResponse = {
-    searchType: "URL";
-    results: { apiVideoId: string }[];
-};
+export interface VideoSearchResponse {
+    results: VideoSummaryItem[];
+    nextPageToken: string | null;
+    totalResults: number;
+    hasMore: boolean;
+}
 
-type ChannelSearchResponse = {
-    searchType: "CHANNEL";
-    results: ChannelSearchResult[];
-};
-
-export type SearchResponse = UrlSearchResponse | ChannelSearchResponse;
+export interface ShortsSearchResponse {
+    results: VideoSummaryItem[];
+    nextPageToken: string | null;
+    totalResults: number;
+    hasMore: boolean;
+}

--- a/src/types/video-preview.types.ts
+++ b/src/types/video-preview.types.ts
@@ -4,11 +4,11 @@ import {Channel, Comment, SentimentRatio, VideoDetail} from "./video.types";
 export type VideoSummaryItem = {
     video: Pick<VideoDetail, 'id' | 'title' | 'description' | 'publishedAt' | 'thumbnailUrl' | 'viewCount' | 'likeCount' | 'commentCount' | 'scrapId'>;
     channel: Pick<Channel, 'id' | 'title' | 'thumbnailUrl' | 'subscriberCount' | 'favoriteChannelId'>;
-    analysis: SummaryAnalysis;
+    analysis: SummaryAnalysis | null;
 };
 
 export interface SummaryAnalysis {
-    summary: string;
+    summary: string | null;
     sentimentDistribution: SentimentRatio;
     keywords: string[];
     topComments?: Comment[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -3807,6 +3807,11 @@ react-dom@^19.0.0:
   dependencies:
     scheduler "^0.27.0"
 
+react-intersection-observer@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-10.0.0.tgz#77613d4e819dd170fbac4821c126c046aab69978"
+  integrity sha512-JJRgcnFQoVXmbE5+GXr1OS1NDD1gHk0HyfpLcRf0575IbJz+io8yzs4mWVlfaqOQq1FiVjLvuYAdEEcrrCfveg==
+
 react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #79

---

### 🚀 어떤 기능을 구현했나요?
- 검색 API를 3개(channels/videos/shorts)로 분리
- 동영상/쇼츠 탭에 무한 스크롤 적용

### 🔥 어떻게 해결했나요?
- Deprecated된 `/search` API 제거하고 개별 API 사용
  - `/search/channels` - 채널 검색
  - `/search/videos` - 동영상 검색 (페이지네이션)
  - `/search/shorts` - 쇼츠 검색 (페이지네이션)
- 통합검색(All Tab)은 3개 API를 병렬로 호출하여 결과 조합
- `searchByQuery` 함수 제거, `searchChannels` 추가
- `searchType` 상태 및 URL 리다이렉트 로직 제거
- `useInfiniteScroll` 훅으로 동영상/쇼츠 무한 스크롤 구현

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- `useSearchQuery.ts` - 3개 API 병렬 호출 및 에러 처리 로직
- `search.service.ts` - API 함수 변경사항 (searchChannels 추가)
- All Tab에서 채널/동영상/쇼츠가 모두 정상 표시되는지
- Video/Shorts Tab에서 무한 스크롤 동작 확인

### 📚 참고 자료, 할 말
-