### PR TITLE
[Feature] 댓글 세부 감정 태그 UI 구현

### DIFF
--- a/src/components/common/Comment/CommentItem.tsx
+++ b/src/components/common/Comment/CommentItem.tsx
@@ -17,6 +17,16 @@ const SENTIMENT_LABEL = {
     other: {text: "기타", color: "bg-gray-200 text-gray-600"},
 } as const;
 
+const DETAIL_EMOTION_MAP: Record<string, { text: string; color: string }> = {
+    JOY: {text: "기쁨", color: "bg-yellow-50 text-yellow-600 border border-yellow-300"},
+    LOVE: {text: "사랑", color: "bg-rose-50 text-rose-600 border border-rose-300"},
+    GRATITUDE: {text: "감사", color: "bg-emerald-50 text-emerald-600 border border-emerald-300"},
+    ANGER: {text: "분노", color: "bg-red-50 text-red-600 border border-red-300"},
+    SADNESS: {text: "슬픔", color: "bg-indigo-50 text-indigo-600 border border-indigo-300"},
+    FEAR: {text: "두려움", color: "bg-purple-50 text-purple-600 border border-purple-300"},
+    NEUTRAL: {text: "중립", color: "bg-gray-50 text-gray-500 border border-gray-300"},
+};
+
 export default function CommentItem({
                                         id,
                                         author,
@@ -26,6 +36,7 @@ export default function CommentItem({
                                         sentiment = "other",
                                         hasReplies = false,
                                         replies: initialReplies,
+                                        detailEmotion = [],
                                     }: Props) {
     const [isRepliesOpen, setIsRepliesOpen] = useState(false);
     const [replies, setReplies] = useState(initialReplies ?? []);
@@ -36,6 +47,7 @@ export default function CommentItem({
     const {selectedText, position, clearSelection} = useTextSelection(commentRef);
 
     const badge = SENTIMENT_LABEL[sentiment] ?? SENTIMENT_LABEL.other;
+    const displayEmotions = detailEmotion.slice(0, 3);
 
     const handleToggleReplies = async () => {
         if (isRepliesOpen) {
@@ -80,6 +92,18 @@ export default function CommentItem({
                                 className={`text-xs px-2 py-[2px] rounded-full font-medium whitespace-nowrap ${badge.color}`}>
                                 {badge.text}
                             </span>
+                            {displayEmotions.map((emotion, index) => {
+                                const emotionStyle = DETAIL_EMOTION_MAP[emotion];
+                                if (!emotionStyle) return null;
+                                return (
+                                    <span
+                                        key={`${emotion}-${index}`}
+                                        className={`text-xs px-2 py-[2px] rounded-full font-medium whitespace-nowrap ${emotionStyle.color}`}
+                                    >
+                                        {emotionStyle.text}
+                                    </span>
+                                );
+                            })}
                         </div>
                         <div className="flex gap-1 items-center flex-shrink-0">
                             <HandThumbUpIcon className="w-4 h-4 text-gray-400"/>

--- a/src/types/video.types.ts
+++ b/src/types/video.types.ts
@@ -44,6 +44,7 @@ export interface Comment {
     text: string;
     likeCount: number;
     sentiment: 'positive' | 'negative' | 'other';
+    detailEmotion?: string[];
     publishedAt: string;
     hasReplies?: boolean;
     replies?: Reply[];


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #85 

---

### 🚀 어떤 기능을 구현했나요?
- 댓글에 세부 감정 태그 표시 기능 추가
- 7가지 감정 분류 (기쁨/사랑/감사/분노/슬픔/두려움/중립)

### 🔥 어떻게 해결했나요?
- Comment 타입에 `detailEmotion?: string[]` 필드 추가
- 감정별 색상 매핑 객체 생성 (`DETAIL_EMOTION_MAP`)
- sentiment 태그 우측에 세부 감정 태그 최대 3개 표시

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 감정별 색상 구분이 명확한지
- 최대 3개 제한 로직

### 📚 참고 자료, 할 말
- 대댓글(Reply)에는 적용하지 않음
- detailEmotion 없으면 기존과 동일하게 표시

<img width="452" height="324" alt="Screenshot 2025-11-11 at 14 08 00" src="https://github.com/user-attachments/assets/aca89ed4-a755-4f5b-b6e3-28153b814f8d" />