### PR TITLE
[Feature] 세부감정 API 연결

### DIFF
--- a/src/components/common/Comment/CommentItem.tsx
+++ b/src/components/common/Comment/CommentItem.tsx
@@ -17,7 +17,7 @@ const SENTIMENT_LABEL = {
     other: {text: "기타", color: "bg-gray-200 text-gray-600"},
 } as const;
 
-const DETAIL_EMOTION_MAP: Record<string, { text: string; color: string }> = {
+const DETAIL_SENTIMENTS_MAP: Record<string, { text: string; color: string }> = {
     JOY: {text: "기쁨", color: "bg-yellow-50 text-yellow-600 border border-yellow-300"},
     LOVE: {text: "사랑", color: "bg-rose-50 text-rose-600 border border-rose-300"},
     GRATITUDE: {text: "감사", color: "bg-emerald-50 text-emerald-600 border border-emerald-300"},
@@ -36,7 +36,7 @@ export default function CommentItem({
                                         sentiment = "other",
                                         hasReplies = false,
                                         replies: initialReplies,
-                                        detailEmotion = [],
+                                        detailSentiments = [],
                                     }: Props) {
     const [isRepliesOpen, setIsRepliesOpen] = useState(false);
     const [replies, setReplies] = useState(initialReplies ?? []);
@@ -47,7 +47,7 @@ export default function CommentItem({
     const {selectedText, position, clearSelection} = useTextSelection(commentRef);
 
     const badge = SENTIMENT_LABEL[sentiment] ?? SENTIMENT_LABEL.other;
-    const displayEmotions = detailEmotion.slice(0, 3);
+    const displayEmotions = detailSentiments.slice(0, 3);
 
     const handleToggleReplies = async () => {
         if (isRepliesOpen) {
@@ -93,7 +93,7 @@ export default function CommentItem({
                                 {badge.text}
                             </span>
                             {displayEmotions.map((emotion, index) => {
-                                const emotionStyle = DETAIL_EMOTION_MAP[emotion];
+                                const emotionStyle = DETAIL_SENTIMENTS_MAP[emotion];
                                 if (!emotionStyle) return null;
                                 return (
                                     <span

--- a/src/components/common/Thumbnail/ShortsThumbnail.tsx
+++ b/src/components/common/Thumbnail/ShortsThumbnail.tsx
@@ -1,33 +1,33 @@
 'use client';
 
 import Image from "next/image";
-import { useState } from "react";
-import { ExclamationTriangleIcon } from "@heroicons/react/16/solid";
+import {useState} from "react";
+import {ExclamationTriangleIcon} from "@heroicons/react/16/solid";
 
 type Props = {
     src: string;
 };
 
-export default function ShortsThumbnail({ src }: Props) {
+export default function ShortsThumbnail({src}: Props) {
     const [hasError, setHasError] = useState(false);
     const showImage = src && src.trim() !== "" && !hasError;
 
     return (
         <div className="relative w-full aspect-[9/16] rounded-2xl overflow-hidden bg-gray-200">
             {showImage ? (
-                        <Image
-                            src={src}
+                <Image
+                    src={src}
                     alt="썸네일"
-                fill
-                className="object-cover"
-                sizes="(max-width: 640px) 50vw, 200px"
-                onError={() => setHasError(true)}
-    />
-) : (
-        <div className="absolute inset-0 flex items-center justify-center text-gray-500 text-sm">
-        <ExclamationTriangleIcon className="size-8 stroke-2 text-gray-400" />
-            </div>
-    )}
-    </div>
-);
+                    fill
+                    className="object-cover"
+                    sizes="(max-width: 640px) 50vw, 200px"
+                    onError={() => setHasError(true)}
+                />
+            ) : (
+                <div className="absolute inset-0 flex items-center justify-center text-gray-500 text-sm">
+                    <ExclamationTriangleIcon className="size-8 stroke-2 text-gray-400"/>
+                </div>
+            )}
+        </div>
+    );
 }

--- a/src/components/common/video-preview/ShortsPreview.tsx
+++ b/src/components/common/video-preview/ShortsPreview.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import {useRouter} from "next/navigation";
-import Thumbnail from "@components/common/Thumbnail/Thumbnail";
 import type {VideoSummaryItem} from "@/types/video-preview.types";
 import AnalysisPanel from "@components/common/video-preview/AnalysisPanel";
 import VideoInfo from "@components/common/video-preview/VideoInfo";
 import SelectButton from "@components/common/SelectButton";
 import {useCompare} from "@/contexts/CompareContext";
+import ShortsThumbnail from "@components/common/Thumbnail/ShortsThumbnail";
 
 type Props = {
     rank?: number;
@@ -32,28 +32,27 @@ export default function VideoPreview({rank, data}: Props) {
 
     return (
         <div
-            className={`flex flex-col lg:flex-row gap-6 w-full ${compareMode ? 'cursor-pointer' : ''}`}
+            className={`flex flex-col sm:flex-row gap-4 w-full items-center sm:items-start ${compareMode ? 'cursor-pointer' : ''}`}
             onClick={handleClick}
         >
-            <div className="flex flex-col sm:flex-row gap-4 flex-1 min-w-0">
-                {rank !== undefined && (
-                    <span className="text-xl font-bold w-6">{rank}</span>
+            {rank !== undefined && (
+                <span className="text-xl font-bold w-6 flex-shrink-0">{rank}</span>
+            )}
+
+            <div className="w-[160px] flex-shrink-0 overflow-hidden rounded-2xl relative">
+                <ShortsThumbnail src={video.thumbnailUrl ?? ""}/>
+
+                {compareMode && (
+                    <div className="absolute top-3 right-3">
+                        <SelectButton selected={selected}/>
+                    </div>
                 )}
-
-                <div className="w-full sm:w-[280px] flex-shrink-0 overflow-hidden rounded-2xl relative">
-                    <Thumbnail src={video.thumbnailUrl ?? ""}/>
-
-                    {compareMode && (
-                        <div className="absolute top-3 right-3">
-                            <SelectButton selected={selected} />
-                        </div>
-                    )}
-                </div>
-
-                <VideoInfo video={video} channel={channel}/>
             </div>
 
-            <AnalysisPanel analysis={analysis} className="w-full lg:w-[40%]"/>
+            <div className="flex-1 min-w-0">
+                <VideoInfo video={video} channel={channel}/>
+                <AnalysisPanel analysis={analysis} className="w-full"/>
+            </div>
         </div>
     );
 }

--- a/src/components/scraps/index.tsx
+++ b/src/components/scraps/index.tsx
@@ -2,17 +2,28 @@
 
 import {useAuth} from "@/contexts/AuthContext";
 import VideoPreviewList from "@components/common/video-preview/VideoPreviewList";
-import {useEffect, useState} from "react";
+import {useEffect, useState, useCallback} from "react";
 import {fetchScrapsVideos} from "@/services/video.service";
 import LoadingSection from "@components/common/LoadingSection";
-import type {VideoSummaryItem} from "@/types/video-preview.types";
+import type {VideoSummaryItem, AnalysisSummaryOnly} from "@/types/video-preview.types";
 import LoginCallout from "@components/common/LoginCallout";
+import {useAIPolling} from "@/hooks/useAIPolling";
 
 export default function Scraps() {
-    const { isLoggedIn } = useAuth();
+    const {isLoggedIn} = useAuth();
     const [isLoading, setIsLoading] = useState(false);
     const [isError, setIsError] = useState(false);
     const [videoList, setVideoList] = useState<VideoSummaryItem[]>([]);
+
+    const handleAIUpdate = useCallback((videoId: string, analysis: AnalysisSummaryOnly) => {
+        setVideoList((prev) =>
+            prev.map((item) =>
+                item.video.id === videoId ? {...item, analysis} : item
+            )
+        );
+    }, []);
+
+    useAIPolling(videoList, handleAIUpdate);
 
     useEffect(() => {
         if (!isLoggedIn) return;
@@ -36,7 +47,7 @@ export default function Scraps() {
         fetch();
     }, [isLoggedIn]);
 
-    if (isLoading) return <LoadingSection message="데이터를 불러오고 있습니다..." />;
+    if (isLoading) return <LoadingSection message="데이터를 불러오고 있습니다..."/>;
     if (isError) return <div className="text-center text-gray-500 py-10">스크랩 정보를 불러오지 못했어요.</div>;
 
     return (

--- a/src/components/search/tabs/AllTab.tsx
+++ b/src/components/search/tabs/AllTab.tsx
@@ -22,13 +22,9 @@ interface Props {
 export default function AllTab({query, channels, videos, shorts, loading}: Props) {
     const router = useRouter();
 
-    if (loading.channels && loading.videos && loading.shorts) {
-        return <LoadingSection message="검색 중입니다..."/>;
-    }
-
     return (
         <div className="flex flex-col gap-8">
-            {!loading.channels && channels && channels.length > 0 && (
+            {channels && channels.length > 0 && (
                 <section>
                     <SearchSectionHeader
                         title="채널"
@@ -42,7 +38,7 @@ export default function AllTab({query, channels, videos, shorts, loading}: Props
                 </section>
             )}
 
-            {!loading.videos && videos.length > 0 && (
+            {videos.length > 0 ? (
                 <section>
                     <SearchSectionHeader
                         title="동영상"
@@ -54,9 +50,11 @@ export default function AllTab({query, channels, videos, shorts, loading}: Props
                         ))}
                     </div>
                 </section>
-            )}
+            ) : loading.videos ? (
+                <div className="text-center py-6 text-gray-400">동영상 검색 중...</div>
+            ) : null}
 
-            {!loading.shorts && shorts.length > 0 && (
+            {shorts.length > 0 ? (
                 <section>
                     <SearchSectionHeader
                         title="Shorts"
@@ -68,7 +66,16 @@ export default function AllTab({query, channels, videos, shorts, loading}: Props
                         ))}
                     </div>
                 </section>
-            )}
+            ) : loading.shorts ? (
+                <div className="text-center py-6 text-gray-400">Shorts 검색 중...</div>
+            ) : null}
+
+            {!loading.videos && !loading.shorts && !loading.channels &&
+                videos.length === 0 && shorts.length === 0 && (!channels || channels.length === 0) && (
+                    <div className="text-center py-20">
+                        <p className="text-gray-500 text-lg">검색 결과가 없습니다.</p>
+                    </div>
+                )}
         </div>
     );
 }

--- a/src/components/search/tabs/AllTab.tsx
+++ b/src/components/search/tabs/AllTab.tsx
@@ -3,7 +3,6 @@ import ChannelPreview from "@components/search/ChannelPreview";
 import VideoPreview from "@components/common/video-preview/VideoPreview";
 import ShortsPreview from "@components/common/video-preview/ShortsPreview";
 import SearchSectionHeader from "@components/search/SearchSectionHeader";
-import LoadingSection from "@components/common/LoadingSection";
 import type {ChannelSearchResult} from "@/types/channel.types";
 import type {VideoSummaryItem} from "@/types/video-preview.types";
 

--- a/src/components/search/tabs/ShortsTab.tsx
+++ b/src/components/search/tabs/ShortsTab.tsx
@@ -20,13 +20,16 @@ export default function ShortsTab({shorts, loading, initialNextPageToken, initia
         initialHasMore,
         searchFunction: searchShorts,
     });
-
-    if (loading) {
-        return <LoadingSection message="Shorts 검색 중..."/>;
-    }
-
+    
     if (!data || data.length === 0) {
-        return <p className="text-gray-500">검색 결과가 없습니다.</p>;
+        return (
+            <div className="text-center py-10">
+                <p className="text-gray-500 text-lg">검색 결과가 없습니다.</p>
+                {loading && (
+                    <p className="text-gray-400 text-sm mt-2">검색 중...</p>
+                )}
+            </div>
+        );
     }
 
     return (
@@ -41,8 +44,7 @@ export default function ShortsTab({shorts, loading, initialNextPageToken, initia
                 <div ref={scrollRef} className="py-4 text-center">
                     {isLoadingMore && (
                         <div className="flex items-center justify-center gap-2">
-                            <div
-                                className="w-8 h-8 border-4 border-gray-300 border-t-blue-500 rounded-full animate-spin"/>
+                            <div className="w-8 h-8 border-4 border-gray-300 border-t-blue-500 rounded-full animate-spin"/>
                             <span className="text-gray-600">더 많은 Shorts를 불러오는 중...</span>
                         </div>
                     )}

--- a/src/components/search/tabs/ShortsTab.tsx
+++ b/src/components/search/tabs/ShortsTab.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import ShortsPreview from "@components/common/video-preview/ShortsPreview";
-import LoadingSection from "@components/common/LoadingSection";
 import {searchShorts} from "@/services/search.service";
 import {useInfiniteScroll} from "@/hooks/useInfiniteScroll";
 import type {VideoSummaryItem} from "@/types";
@@ -20,7 +19,7 @@ export default function ShortsTab({shorts, loading, initialNextPageToken, initia
         initialHasMore,
         searchFunction: searchShorts,
     });
-    
+
     if (!data || data.length === 0) {
         return (
             <div className="text-center py-10">

--- a/src/components/search/tabs/VideoTab.tsx
+++ b/src/components/search/tabs/VideoTab.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import VideoPreview from "@components/common/video-preview/VideoPreview";
-import LoadingSection from "@components/common/LoadingSection";
 import {searchVideos} from "@/services/search.service";
 import type {VideoSummaryItem} from "@/types/video-preview.types";
 import {useInfiniteScroll} from "@/hooks/useInfiniteScroll";

--- a/src/components/search/tabs/VideoTab.tsx
+++ b/src/components/search/tabs/VideoTab.tsx
@@ -21,12 +21,15 @@ export default function VideoTab({videos, loading, initialNextPageToken, initial
         searchFunction: searchVideos,
     });
 
-    if (loading) {
-        return <LoadingSection message="동영상 검색 중..."/>;
-    }
-
     if (!data || data.length === 0) {
-        return <p className="text-gray-500">검색 결과가 없습니다.</p>;
+        return (
+            <div className="text-center py-10">
+                <p className="text-gray-500 text-lg">검색 결과가 없습니다.</p>
+                {loading && (
+                    <p className="text-gray-400 text-sm mt-2">검색 중...</p>
+                )}
+            </div>
+        );
     }
 
     return (
@@ -39,8 +42,7 @@ export default function VideoTab({videos, loading, initialNextPageToken, initial
                 <div ref={scrollRef} className="py-4 text-center">
                     {isLoadingMore && (
                         <div className="flex items-center justify-center gap-2">
-                            <div
-                                className="w-8 h-8 border-4 border-gray-300 border-t-blue-500 rounded-full animate-spin"/>
+                            <div className="w-8 h-8 border-4 border-gray-300 border-t-blue-500 rounded-full animate-spin"/>
                             <span className="text-gray-600">더 많은 동영상을 불러오는 중...</span>
                         </div>
                     )}

--- a/src/components/trending/index.tsx
+++ b/src/components/trending/index.tsx
@@ -1,16 +1,29 @@
 'use client';
 
-import {useEffect, useState} from "react";
+import {useEffect, useState, useCallback} from "react";
 import VideoPreviewList from "@components/common/video-preview/VideoPreviewList";
-import type {VideoSummaryItem} from "@/types/video-preview.types";
+import type {VideoSummaryItem, AnalysisSummaryOnly} from "@/types/video-preview.types";
 import {fetchTrendingVideos} from "@/services/video.service";
 import LoadingSection from "@components/common/LoadingSection";
+import {useAIPolling} from "@/hooks/useAIPolling";
 
 export default function Trending() {
     const [videoList, setVideoList] = useState<VideoSummaryItem[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [isError, setIsError] = useState(false);
     const maxResults = 10;
+
+    // AI 분석 업데이트 콜백
+    const handleAIUpdate = useCallback((videoId: string, analysis: AnalysisSummaryOnly) => {
+        setVideoList((prev) =>
+            prev.map((item) =>
+                item.video.id === videoId ? { ...item, analysis } : item
+            )
+        );
+    }, []);
+
+    // AI 폴링 시작
+    useAIPolling(videoList, handleAIUpdate);
 
     useEffect(() => {
         const fetch = async () => {

--- a/src/hooks/useAIPolling.ts
+++ b/src/hooks/useAIPolling.ts
@@ -1,0 +1,77 @@
+import { useState, useEffect, useMemo } from 'react';
+import { VideoSummaryItem, AnalysisSummaryOnly } from '@/types/video-preview.types';
+import { isAIAnalysisComplete } from '@/utils/ai-analysis';
+import { fetchVideoAISummary } from '@/services/video.service';
+
+const AI_POLLING_INTERVAL = 5000;
+const AI_MAX_RETRIES = 4;
+
+interface PollingState {
+    [videoId: string]: number;
+}
+
+export function useAIPolling(
+    videos: VideoSummaryItem[],
+    onUpdate: (videoId: string, analysis: AnalysisSummaryOnly) => void
+) {
+    const [pollingState, setPollingState] = useState<PollingState>({});
+
+    const needsPolling = useMemo(() =>
+            videos.filter(
+                (video) =>
+                    !isAIAnalysisComplete(video.analysis) &&
+                    (pollingState[video.video.id] ?? 0) < AI_MAX_RETRIES
+            ),
+        [videos, pollingState]
+    );
+
+    useEffect(() => {
+        if (needsPolling.length === 0) return;
+
+        let mounted = true;
+        const timeoutId = window.setTimeout(async () => {
+            console.log(`[AI 폴링] ${needsPolling.length}개 영상 확인 중...`);
+
+            const promises = needsPolling.map(async (video) => {
+                try {
+                    const ai = await fetchVideoAISummary(video.video.id);
+
+                    if (!mounted) return;
+
+                    if (isAIAnalysisComplete(ai)) {
+                        console.log(`[AI 폴링] ${video.video.id} 완료!`);
+                        onUpdate(video.video.id, ai);
+                    } else {
+                        console.log(`[AI 폴링] ${video.video.id} 아직 분석 중...`);
+                        setPollingState((prev) => ({
+                            ...prev,
+                            [video.video.id]: (prev[video.video.id] ?? 0) + 1,
+                        }));
+                    }
+                } catch (err) {
+                    console.error(`[AI 폴링] ${video.video.id} 에러:`, err);
+                    if (mounted) {
+                        setPollingState((prev) => ({
+                            ...prev,
+                            [video.video.id]: (prev[video.video.id] ?? 0) + 1,
+                        }));
+                    }
+                }
+            });
+
+            await Promise.all(promises);
+        }, AI_POLLING_INTERVAL);
+
+        return () => {
+            mounted = false;
+            clearTimeout(timeoutId);
+        };
+    }, [needsPolling, onUpdate]);
+
+    // videos 변경 시 폴링 상태 초기화
+    useEffect(() => {
+        setPollingState({});
+    }, [videos.length]);
+
+    return { pollingState };
+}

--- a/src/hooks/useMainPageData.ts
+++ b/src/hooks/useMainPageData.ts
@@ -1,7 +1,9 @@
-import {useState, useEffect} from 'react';
+import {useState, useEffect, useCallback} from 'react';
 import {fetchFavoriteChannelVideo, fetchTrendingVideos, fetchScrapVideos} from '@/services/main.service';
 import {MainPageData} from '@/types/main.types';
 import {useAuth} from '@/contexts/AuthContext';
+import {useAIPolling} from '@/hooks/useAIPolling';
+import {AnalysisSummaryOnly} from '@/types/video-preview.types';
 
 export function useMainPageData() {
     const {isLoggedIn} = useAuth();
@@ -17,6 +19,27 @@ export function useMainPageData() {
         trending: true,
         scraps: true,
     });
+
+    const handleTrendingAIUpdate = useCallback((videoId: string, analysis: AnalysisSummaryOnly) => {
+        setData((prev) => ({
+            ...prev,
+            trendingVideos: prev.trendingVideos.map((item) =>
+                item.video.id === videoId ? { ...item, analysis } : item
+            ),
+        }));
+    }, []);
+
+    const handleScrapAIUpdate = useCallback((videoId: string, analysis: AnalysisSummaryOnly) => {
+        setData((prev) => ({
+            ...prev,
+            scrapVideos: prev.scrapVideos.map((item) =>
+                item.video.id === videoId ? { ...item, analysis } : item
+            ),
+        }));
+    }, []);
+
+    useAIPolling(data.trendingVideos, handleTrendingAIUpdate);
+    useAIPolling(data.scrapVideos, handleScrapAIUpdate);
 
     useEffect(() => {
         let mounted = true;
@@ -54,7 +77,6 @@ export function useMainPageData() {
                     setIsLoading((prev) => ({...prev, scraps: false}));
                 });
         } else {
-            // 비로그인: 보호 섹션 로딩 종료 표시
             setIsLoading((prev) => ({...prev, favoriteChannels: false, scraps: false}));
             setData((prev) => ({...prev, favoriteChannelVideo: null, scrapVideos: []}));
         }

--- a/src/hooks/useSearchQuery.ts
+++ b/src/hooks/useSearchQuery.ts
@@ -1,7 +1,8 @@
-import {useState, useEffect} from "react";
+import {useState, useEffect, useCallback} from "react";
 import {useRouter} from "next/navigation";
 import {searchChannels, searchVideos, searchShorts} from "@/services/search.service";
-import type {VideoSummaryItem, ChannelSearchResult} from "@/types";
+import type {VideoSummaryItem, ChannelSearchResult, AnalysisSummaryOnly} from "@/types";
+import {useAIPolling} from "@/hooks/useAIPolling";
 
 type TabType = 'all' | 'video' | 'shorts' | 'channel';
 
@@ -36,6 +37,29 @@ const initialState: SearchState = {
 export function useSearchQuery(query: string | null, activeTab: TabType) {
     const router = useRouter();
     const [state, setState] = useState<SearchState>(initialState);
+
+    // AI 폴링 업데이트 콜백
+    const handleVideoAIUpdate = useCallback((videoId: string, analysis: AnalysisSummaryOnly) => {
+        setState((prev) => ({
+            ...prev,
+            videos: prev.videos.map((item) =>
+                item.video.id === videoId ? { ...item, analysis } : item
+            ),
+        }));
+    }, []);
+
+    const handleShortsAIUpdate = useCallback((videoId: string, analysis: AnalysisSummaryOnly) => {
+        setState((prev) => ({
+            ...prev,
+            shorts: prev.shorts.map((item) =>
+                item.video.id === videoId ? { ...item, analysis } : item
+            ),
+        }));
+    }, []);
+
+    // AI 폴링 시작
+    useAIPolling(state.videos, handleVideoAIUpdate);
+    useAIPolling(state.shorts, handleShortsAIUpdate);
 
     useEffect(() => {
         if (!query) return;
@@ -162,7 +186,7 @@ export function useSearchQuery(query: string | null, activeTab: TabType) {
 
                     setState((prev) => ({
                         ...prev,
-                        channels: result,  // 배열 직접 저장
+                        channels: result,
                         loading: {...prev.loading, channels: false},
                     }));
 

--- a/src/hooks/useSearchQuery.ts
+++ b/src/hooks/useSearchQuery.ts
@@ -57,7 +57,6 @@ export function useSearchQuery(query: string | null, activeTab: TabType) {
         }));
     }, []);
 
-    // AI 폴링 시작
     useAIPolling(state.videos, handleVideoAIUpdate);
     useAIPolling(state.shorts, handleShortsAIUpdate);
 
@@ -65,16 +64,16 @@ export function useSearchQuery(query: string | null, activeTab: TabType) {
         if (!query) return;
 
         const fetchData = async () => {
-            // 초기화
-            setState(initialState);
+            setState({
+                channels: null,
+                videos: [],
+                shorts: [],
+                loading: {channels: true, videos: true, shorts: true}, // 백그라운드 로딩
+                videoPagination: {nextPageToken: null, hasMore: false},
+                shortsPagination: {nextPageToken: null, hasMore: false},
+            });
 
             if (activeTab === 'all') {
-                // 통합 탭: 모든 데이터 병렬 로딩
-                setState((prev) => ({
-                    ...prev,
-                    loading: {channels: true, videos: true, shorts: true},
-                }));
-
                 console.log('🔍 [All Tab] 검색 시작:', query);
 
                 const [channelResult, videoResult, shortsResult] = await Promise.allSettled([
@@ -83,57 +82,36 @@ export function useSearchQuery(query: string | null, activeTab: TabType) {
                     searchShorts(query),
                 ]);
 
-                console.log('📦 [All Tab] 채널 결과:', channelResult);
-                console.log('📦 [All Tab] 동영상 결과:', videoResult);
-                console.log('📦 [All Tab] 쇼츠 결과:', shortsResult);
-
                 setState((prev) => {
                     const newState = {...prev, loading: {channels: false, videos: false, shorts: false}};
 
-                    // 채널 검색
                     if (channelResult.status === 'fulfilled') {
                         newState.channels = channelResult.value;
-                        console.log('✅ [All Tab] 채널 설정:', newState.channels.length);
-                    } else {
-                        console.error('❌ [All Tab] 채널 검색 실패:', channelResult.reason);
                     }
 
-                    // 동영상
                     if (videoResult.status === 'fulfilled') {
                         newState.videos = videoResult.value.results;
                         newState.videoPagination = {
                             nextPageToken: videoResult.value.nextPageToken,
                             hasMore: videoResult.value.hasMore,
                         };
-                        console.log('✅ [All Tab] 동영상 설정:', newState.videos.length);
-                    } else {
-                        console.error('❌ [All Tab] 동영상 검색 실패:', videoResult.reason);
                     }
 
-                    // 쇼츠
                     if (shortsResult.status === 'fulfilled') {
                         newState.shorts = shortsResult.value.results;
                         newState.shortsPagination = {
                             nextPageToken: shortsResult.value.nextPageToken,
                             hasMore: shortsResult.value.hasMore,
                         };
-                        console.log('✅ [All Tab] 쇼츠 설정:', newState.shorts.length);
-                    } else {
-                        console.error('❌ [All Tab] 쇼츠 검색 실패:', shortsResult.reason);
                     }
 
                     return newState;
                 });
             } else if (activeTab === 'video') {
-                // 동영상 탭
-                setState((prev) => ({...prev, loading: {...prev.loading, videos: true}}));
-
                 console.log('🔍 [Video Tab] 검색 시작:', query);
 
                 try {
                     const result = await searchVideos(query);
-                    console.log('✅ [Video Tab] API 응답:', result);
-
                     setState((prev) => ({
                         ...prev,
                         videos: result.results,
@@ -143,22 +121,15 @@ export function useSearchQuery(query: string | null, activeTab: TabType) {
                         },
                         loading: {...prev.loading, videos: false},
                     }));
-
-                    console.log('✅ [Video Tab] 동영상 설정 완료:', result.results.length, '개');
                 } catch (error) {
-                    console.error("❌ [Video Tab] 동영상 검색 실패:", error);
+                    console.error("❌ [Video Tab] 실패:", error);
                     setState((prev) => ({...prev, loading: {...prev.loading, videos: false}}));
                 }
             } else if (activeTab === 'shorts') {
-                // 쇼츠 탭
-                setState((prev) => ({...prev, loading: {...prev.loading, shorts: true}}));
-
                 console.log('🔍 [Shorts Tab] 검색 시작:', query);
 
                 try {
                     const result = await searchShorts(query);
-                    console.log('✅ [Shorts Tab] API 응답:', result);
-
                     setState((prev) => ({
                         ...prev,
                         shorts: result.results,
@@ -168,31 +139,22 @@ export function useSearchQuery(query: string | null, activeTab: TabType) {
                         },
                         loading: {...prev.loading, shorts: false},
                     }));
-
-                    console.log('✅ [Shorts Tab] 쇼츠 설정 완료:', result.results.length, '개');
                 } catch (error) {
-                    console.error("❌ [Shorts Tab] 쇼츠 검색 실패:", error);
+                    console.error("❌ [Shorts Tab] 실패:", error);
                     setState((prev) => ({...prev, loading: {...prev.loading, shorts: false}}));
                 }
             } else if (activeTab === 'channel') {
-                // 채널 탭
-                setState((prev) => ({...prev, loading: {...prev.loading, channels: true}}));
-
                 console.log('🔍 [Channel Tab] 검색 시작:', query);
 
                 try {
                     const result = await searchChannels(query);
-                    console.log('✅ [Channel Tab] API 응답:', result);
-
                     setState((prev) => ({
                         ...prev,
                         channels: result,
                         loading: {...prev.loading, channels: false},
                     }));
-
-                    console.log('✅ [Channel Tab] 채널 설정 완료:', result.length, '개');
                 } catch (error) {
-                    console.error("❌ [Channel Tab] 채널 검색 실패:", error);
+                    console.error("❌ [Channel Tab] 실패:", error);
                     setState((prev) => ({...prev, loading: {...prev.loading, channels: false}}));
                 }
             }

--- a/src/hooks/useVideoDetail.ts
+++ b/src/hooks/useVideoDetail.ts
@@ -8,9 +8,12 @@ import type {
 } from "@/types/video-detail.types";
 import {fetchVideoBasic, fetchVideoAnalysis, fetchVideoComments, fetchVideoAI} from "@/services/video.service";
 import {fetchFilteredComments} from "@/services/search.service";
+import {isAIAnalysisComplete} from "@/utils/ai-analysis";
 
 const MAX_RETRIES = 24;
 const RETRY_INTERVAL = 6000;
+const AI_POLLING_INTERVAL = 5000;
+const AI_MAX_RETRIES = 10;
 
 export function useVideoDetail(videoId: string): UseVideoDetailReturn {
     const [basicInfo, setBasicInfo] = useState<VideoBasicInfo | null>(null);
@@ -31,9 +34,11 @@ export function useVideoDetail(videoId: string): UseVideoDetailReturn {
 
     const [isProcessing, setIsProcessing] = useState(false);
     const [retryCount, setRetryCount] = useState(0);
+    const [aiPollingCount, setAiPollingCount] = useState(0);
     const [error, setError] = useState(false);
     const playerRef = useRef<YouTubePlayerRef | null>(null);
 
+    // 기본 정보 로딩
     useEffect(() => {
         let mounted = true;
         let timeoutId: number;
@@ -84,6 +89,7 @@ export function useVideoDetail(videoId: string): UseVideoDetailReturn {
         };
     }, [videoId]);
 
+    // 병렬 데이터 로딩
     useEffect(() => {
         if (!basicInfo) return;
         let mounted = true;
@@ -109,14 +115,55 @@ export function useVideoDetail(videoId: string): UseVideoDetailReturn {
                 basic: false,
                 analysis: !analysis,
                 comments: !commentsList || commentsList.length === 0,
-                ai: !ai,
+                ai: !isAIAnalysisComplete(ai),
             });
+
+            if (!isAIAnalysisComplete(ai)) {
+                setAiPollingCount(0);
+            }
         });
 
         return () => {
             mounted = false;
         };
     }, [videoId, basicInfo]);
+
+    useEffect(() => {
+        if (!isLoading.ai) return;
+        if (aiPollingCount >= AI_MAX_RETRIES) {
+            console.log('[AI 폴링] 최대 재시도 횟수 도달');
+            return;
+        }
+
+        let mounted = true;
+        const timeoutId = window.setTimeout(async () => {
+            try {
+                console.log(`[AI 폴링] ${aiPollingCount + 1}차 시도 중...`);
+                const ai = await fetchVideoAI(videoId);
+
+                if (!mounted) return;
+
+                if (isAIAnalysisComplete(ai)) {
+                    console.log('[AI 폴링] 분석 완료!', ai);
+                    setAIAnalysis(ai);
+                    setIsLoading(prev => ({...prev, ai: false}));
+                } else {
+                    console.log('[AI 폴링] 아직 분석 중...');
+                    setAiPollingCount(prev => prev + 1);
+                }
+            } catch (err) {
+                console.error('[AI 폴링] 에러:', err);
+                if (mounted) {
+                    setAiPollingCount(prev => prev + 1);
+                }
+            }
+        }, AI_POLLING_INTERVAL);
+
+        return () => {
+            mounted = false;
+            clearTimeout(timeoutId);
+        };
+    }, [videoId, isLoading.ai, aiPollingCount]);
 
     const handleSeek = useCallback<VideoDetailActions['handleSeek']>((timeString) => {
         const parts = timeString.split(":").map(Number);

--- a/src/services/video.service.ts
+++ b/src/services/video.service.ts
@@ -13,7 +13,7 @@ import {
     VideoAIAnalysis,
     CommentRepliesResponse
 } from "@/types/video.types";
-import {VideoSummaryItem} from "@/types/video-preview.types";
+import {VideoSummaryItem, AnalysisSummaryOnly} from "@/types/video-preview.types";
 
 export const fetchVideoBasic = async (apiVideoId: string): Promise<VideoBasicInfo> => {
     const res = await api.get<VideoBasicResponse>(`/videos/${apiVideoId}/basic`);
@@ -31,6 +31,12 @@ export const fetchVideoComments = async (apiVideoId: string): Promise<Comment[]>
 };
 
 export const fetchVideoAI = async (apiVideoId: string): Promise<VideoAIAnalysis> => {
+    const res = await api.get<VideoAIResponse>(`/videos/${apiVideoId}/ai`);
+    return res.data.data;
+};
+
+// 프리뷰용 AI 분석 조회 (새로 추가)
+export const fetchVideoAISummary = async (apiVideoId: string): Promise<AnalysisSummaryOnly> => {
     const res = await api.get<VideoAIResponse>(`/videos/${apiVideoId}/ai`);
     return res.data.data;
 };

--- a/src/types/video.types.ts
+++ b/src/types/video.types.ts
@@ -44,7 +44,7 @@ export interface Comment {
     text: string;
     likeCount: number;
     sentiment: 'positive' | 'negative' | 'other';
-    detailEmotion?: string[];
+    detailSentiments?: string[];
     publishedAt: string;
     hasReplies?: boolean;
     replies?: Reply[];

--- a/src/utils/ai-analysis.ts
+++ b/src/utils/ai-analysis.ts
@@ -1,0 +1,17 @@
+import { VideoAIAnalysis } from '@/types/video.types';
+import { SummaryAnalysis } from '@/types/video-preview.types';
+
+/**
+ * AI 분석이 완료되었는지 판단
+ * summary 또는 keywords가 존재하면 완료로 간주
+ */
+export function isAIAnalysisComplete(
+    aiAnalysis: VideoAIAnalysis | SummaryAnalysis | null
+): boolean {
+    if (!aiAnalysis) return false;
+
+    const hasSummary = aiAnalysis.summary !== null && aiAnalysis.summary !== '';
+    const hasKeywords = Array.isArray(aiAnalysis.keywords) && aiAnalysis.keywords.length > 0;
+
+    return hasSummary || hasKeywords;
+}


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #89

---

### 🚀 어떤 기능을 구현했나요?
- 댓글 세부 감정 7가지 API 연결 및 렌더링
- AI 분석 자동 폴링 (상세/메인/검색/스크랩/인기급상승)
- 검색 결과 즉시 표시 (백그라운드 로딩)
- 쇼츠 레이아웃 개선

### 🔥 어떻게 해결했나요?
- `useAIPolling` 훅으로 여러 영상 동시 폴링 (5초 간격, 최대 10회)
- 검색 시 빈 state 즉시 표시 후 백그라운드 로딩
- 쇼츠 썸네일 크기 조정 및 모바일 가운데 정렬

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- AI 폴링 로직 (백엔드 부하 가능성)
- 검색 UX 개선 부분

### 📚 참고 자료, 할 말
- AI 폴링으로 백엔드 요청 증가, 필요시 간격/횟수 조정 가능