### PR TITLE
refactor: 상세 페이지 basic API 분리 (#96)

### DIFF
--- a/src/components/videos/index.tsx
+++ b/src/components/videos/index.tsx
@@ -90,6 +90,7 @@ export default function Detail({videoId}: { videoId: string }) {
 
             <VideoInfo
                 data={data.basicInfo}
+                userState={data.userState}
                 onPlayerReady={(ref) => (playerRef.current = ref)}
             />
 

--- a/src/components/videos/video-info/index.tsx
+++ b/src/components/videos/video-info/index.tsx
@@ -4,7 +4,7 @@ import {useEffect, useRef, useState, useCallback} from "react";
 import {ChevronDownIcon} from "@heroicons/react/24/solid";
 import YouTubePlayer, {YouTubePlayerRef} from "./YoutubePlayer";
 import {formatDate, formatNumber} from "@/utils/data-format";
-import type {VideoBasicInfo} from "@/types";
+import type {VideoBasicInfo, VideoUserState} from "@/types";
 import {useAuth} from "@/contexts/AuthContext";
 import {createScrap, deleteScrap} from "@/services/video.service";
 import {useFavoriteChannel} from "@/hooks/useFavoriteChannel";
@@ -12,14 +12,15 @@ import {BookmarkIcon, HeartIcon} from '@/components/icons';
 
 interface Props {
     data: VideoBasicInfo;
+    userState: VideoUserState | null;
     onPlayerReady?: (ref: YouTubePlayerRef) => void;
 }
 
-export default function VideoInfoSection({data, onPlayerReady}: Props) {
+export default function VideoInfoSection({data, userState, onPlayerReady}: Props) {
     const {video, channel} = data;
     const {isLoggedIn, handleLogin} = useAuth();
 
-    const [scrapId, setScrapId] = useState<number | null>(video.scrapId ?? null);
+    const [scrapId, setScrapId] = useState<number | null>(userState?.scrapId ?? null);
     const [isExpanded, setIsExpanded] = useState(false);
     const [videoHeight, setVideoHeight] = useState(0);
 
@@ -29,8 +30,12 @@ export default function VideoInfoSection({data, onPlayerReady}: Props) {
         channelId: channel.id,
         channelTitle: channel.title,
         channelThumbnail: channel.thumbnailUrl,
-        initialFavoriteId: channel.favoriteChannelId ?? null,
+        initialFavoriteId: userState?.favoriteChannelId ?? null,
     });
+
+    useEffect(() => {
+        setScrapId(userState?.scrapId ?? null);
+    }, [userState?.scrapId]);
 
     useEffect(() => {
         if (!leftRef.current) return;

--- a/src/hooks/useVideoDetail.ts
+++ b/src/hooks/useVideoDetail.ts
@@ -1,12 +1,12 @@
 import {useState, useEffect, useCallback, useRef} from "react";
-import type {Comment, VideoBasicInfo, VideoAnalysisInfo, VideoAIAnalysis} from "@/types";
+import type {Comment, VideoBasicInfo, VideoAnalysisInfo, VideoAIAnalysis, VideoUserState} from "@/types";
 import type {YouTubePlayerRef} from "@components/videos/video-info/YoutubePlayer";
 import type {
     VideoDetailLoadingState,
     UseVideoDetailReturn,
     VideoDetailActions
 } from "@/types/video-detail.types";
-import {fetchVideoBasic, fetchVideoAnalysis, fetchVideoComments, fetchVideoAI} from "@/services/video.service";
+import {fetchVideoBasic, fetchVideoAnalysis, fetchVideoComments, fetchVideoAI, fetchVideoUserState} from "@/services/video.service";
 import {fetchFilteredComments} from "@/services/search.service";
 import {isAIAnalysisComplete} from "@/utils/ai-analysis";
 import {POLLING_CONFIG} from "@/config/polling";
@@ -18,7 +18,6 @@ const AI_POLLING_INTERVAL = POLLING_CONFIG.detail.interval;
 const AI_MAX_RETRIES = POLLING_CONFIG.detail.maxRetries;
 const AI_INITIAL_DELAY = POLLING_CONFIG.detail.initialDelay;
 
-// 폴링 실패 시 기본값 (분석 완료했지만 결과 없음)
 const EMPTY_AI_ANALYSIS: VideoAIAnalysis = {
     summary: null,
     isWarning: false,
@@ -29,6 +28,7 @@ const EMPTY_AI_ANALYSIS: VideoAIAnalysis = {
 
 export function useVideoDetail(videoId: string): UseVideoDetailReturn {
     const [basicInfo, setBasicInfo] = useState<VideoBasicInfo | null>(null);
+    const [userState, setUserState] = useState<VideoUserState | null>(null);
     const [analysisInfo, setAnalysisInfo] = useState<VideoAnalysisInfo | null>(null);
     const [comments, setComments] = useState<Comment[]>([]);
     const [aiAnalysis, setAIAnalysis] = useState<VideoAIAnalysis | null>(null);
@@ -50,7 +50,6 @@ export function useVideoDetail(videoId: string): UseVideoDetailReturn {
     const [error, setError] = useState(false);
     const playerRef = useRef<YouTubePlayerRef | null>(null);
 
-    // 기본 정보 로딩
     useEffect(() => {
         let mounted = true;
         let timeoutId: number;
@@ -64,6 +63,15 @@ export function useVideoDetail(videoId: string): UseVideoDetailReturn {
                 setBasicInfo(result);
                 setIsProcessing(false);
                 setRetryCount(0);
+
+                try {
+                    const userStateResult = await fetchVideoUserState(videoId);
+                    if (mounted) {
+                        setUserState(userStateResult);
+                    }
+                } catch {
+                    console.log('[사용자 상태] 조회 실패 (비로그인 상태일 수 있음)');
+                }
 
             } catch (err: unknown) {
                 if (!mounted) return;
@@ -104,7 +112,6 @@ export function useVideoDetail(videoId: string): UseVideoDetailReturn {
         };
     }, [videoId]);
 
-    // 병렬 데이터 로딩
     useEffect(() => {
         if (!basicInfo) return;
         let mounted = true;
@@ -143,7 +150,6 @@ export function useVideoDetail(videoId: string): UseVideoDetailReturn {
         };
     }, [videoId, basicInfo]);
 
-    // AI 폴링
     useEffect(() => {
         if (!isLoading.ai) return;
         if (aiPollingCount >= AI_MAX_RETRIES) {
@@ -226,6 +232,7 @@ export function useVideoDetail(videoId: string): UseVideoDetailReturn {
     return {
         data: {
             basicInfo,
+            userState,
             analysisInfo,
             comments,
             aiAnalysis,

--- a/src/services/main.service.ts
+++ b/src/services/main.service.ts
@@ -9,7 +9,7 @@ async function fetchNoStore(input: RequestInfo, init?: RequestInit) {
     return fetch(input, {credentials: 'include', cache: 'no-store', ...init});
 }
 
-/** 공통: 4xx를 “정상 흐름”으로 처리할지 여부 */
+/** 공통: 4xx를 "정상 흐름"으로 처리할지 여부 */
 function isBenign4xx(status: number) {
     return status === 400 || status === 401 || status === 403 || status === 404;
 }
@@ -63,8 +63,8 @@ export async function fetchFavoriteChannelVideo(): Promise<FavoriteChannelData |
 
         const latestVideo: VideoSummaryItem | null = videoSummary
             ? {
-                video: {...videoSummary.video, scrapId: null},
-                channel: {...videoSummary.channel, favoriteChannelId: null},
+                video: videoSummary.video,
+                channel: videoSummary.channel,
                 analysis: videoSummary.analysis,
             }
             : null;
@@ -99,8 +99,8 @@ export async function fetchScrapVideos(): Promise<VideoSummaryItem[]> {
         const list = json?.data ?? [];
 
         return list.map((item) => ({
-            video: {...item.video, scrapId: null},
-            channel: {...item.channel, favoriteChannelId: null},
+            video: item.video,
+            channel: item.channel,
             analysis: item.analysis,
         }));
     } catch (e) {
@@ -127,8 +127,8 @@ export async function fetchTrendingVideos(): Promise<VideoSummaryItem[]> {
         const list = json?.data ?? [];
 
         return list.map((item) => ({
-            video: {...item.video, scrapId: null},
-            channel: {...item.channel, favoriteChannelId: null},
+            video: item.video,
+            channel: item.channel,
             analysis: item.analysis,
         }));
     } catch (e) {

--- a/src/services/video.service.ts
+++ b/src/services/video.service.ts
@@ -11,7 +11,7 @@ import {
     VideoBasicInfo,
     VideoAnalysisInfo,
     VideoAIAnalysis,
-    CommentRepliesResponse
+    CommentRepliesResponse, VideoUserStateResponse, VideoUserState
 } from "@/types/video.types";
 import {VideoSummaryItem, AnalysisSummaryOnly} from "@/types/video-preview.types";
 
@@ -19,6 +19,11 @@ export const fetchVideoBasic = async (apiVideoId: string): Promise<VideoBasicInf
     const res = await api.get<VideoBasicResponse>(`/videos/${apiVideoId}/basic`);
     return res.data.data;
 };
+
+export const fetchVideoUserState = async (apiVideoId: string): Promise<VideoUserState> => {
+    const res = await api.get<VideoUserStateResponse>(`/videos/${apiVideoId}/user-state`);
+    return res.data.data;
+}
 
 export const fetchVideoAnalysis = async (apiVideoId: string): Promise<VideoAnalysisInfo> => {
     const res = await api.get<VideoAnalysisResponse>(`/videos/${apiVideoId}/analysis`);

--- a/src/types/video-detail.types.ts
+++ b/src/types/video-detail.types.ts
@@ -1,9 +1,10 @@
-import { VideoBasicInfo, VideoAnalysisInfo, VideoAIAnalysis, Comment } from './video.types';
+import { VideoBasicInfo, VideoAnalysisInfo, VideoAIAnalysis, Comment, VideoUserState } from './video.types';
 import { YouTubePlayerRef } from '@components/videos/video-info/YoutubePlayer';
 import { MutableRefObject } from 'react';
 
 export interface VideoDetailData {
     basicInfo: VideoBasicInfo | null;
+    userState: VideoUserState | null;
     analysisInfo: VideoAnalysisInfo | null;
     comments: Comment[];
     aiAnalysis: VideoAIAnalysis | null;

--- a/src/types/video-preview.types.ts
+++ b/src/types/video-preview.types.ts
@@ -2,8 +2,8 @@ import {BaseApiResponse} from "./common.types";
 import {Channel, Comment, SentimentRatio, VideoDetail} from "./video.types";
 
 export type VideoSummaryItem = {
-    video: Pick<VideoDetail, 'id' | 'title' | 'description' | 'publishedAt' | 'thumbnailUrl' | 'viewCount' | 'likeCount' | 'commentCount' | 'scrapId'>;
-    channel: Pick<Channel, 'id' | 'title' | 'thumbnailUrl' | 'subscriberCount' | 'favoriteChannelId'>;
+    video: Pick<VideoDetail, 'id' | 'title' | 'description' | 'publishedAt' | 'thumbnailUrl' | 'viewCount' | 'likeCount' | 'commentCount'>;
+    channel: Pick<Channel, 'id' | 'title' | 'thumbnailUrl' | 'subscriberCount'>;
     analysis: SummaryAnalysis | null;
 };
 

--- a/src/types/video.types.ts
+++ b/src/types/video.types.ts
@@ -16,7 +16,6 @@ export interface VideoDetail {
     viewCount: number;
     likeCount: number;
     commentCount: number;
-    scrapId?: number | null;
 }
 
 export interface Channel {
@@ -24,7 +23,6 @@ export interface Channel {
     title: string;
     thumbnailUrl: string;
     subscriberCount: number;
-    favoriteChannelId?: number | null;
 }
 
 export interface VideoAnalysis {
@@ -91,6 +89,11 @@ export interface VideoBasicInfo {
     channel: Channel;
 }
 
+export interface VideoUserState {
+    scrapId: number | null;
+    favoriteChannelId: number | null;
+}
+
 export interface VideoAnalysisInfo {
     commentHistogram: HourlyCommentCount[];
     popularTimestamps: TimestampMention[];
@@ -106,11 +109,6 @@ export interface VideoAIAnalysis {
     keywords: string[];
 }
 
-export type VideoBasicResponse = BaseApiResponse<VideoBasicInfo>;
-export type VideoAnalysisResponse = BaseApiResponse<VideoAnalysisInfo>;
-export type VideoCommentsResponse = BaseApiResponse<Comment[]>;
-export type VideoAIResponse = BaseApiResponse<VideoAIAnalysis>;
-
 export interface CommentRepliesResponse {
     timeStamp: string;
     message: string;
@@ -119,3 +117,9 @@ export interface CommentRepliesResponse {
         replies: Reply[];
     };
 }
+
+export type VideoBasicResponse = BaseApiResponse<VideoBasicInfo>;
+export type VideoAnalysisResponse = BaseApiResponse<VideoAnalysisInfo>;
+export type VideoCommentsResponse = BaseApiResponse<Comment[]>;
+export type VideoAIResponse = BaseApiResponse<VideoAIAnalysis>;
+export type VideoUserStateResponse = BaseApiResponse<VideoUserState>;


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #96
---
### 🚀 어떤 기능을 구현했나요?
- 영상 상세 페이지 basic API를 `basic`/`user-state`로 분리

### 🔥 어떻게 해결했나요?
- `basic` 조회 후 `user-state` 순차 호출
- `VideoUserState` 타입 추가 및 Props로 전달

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- user-state의 각 상태가 잘 동기화 되는지

### 📚 참고 자료, 할 말
-