### PR TITLE
Fix/95 search youtube url

### DIFF
--- a/src/components/layout/header/HeaderSearch.tsx
+++ b/src/components/layout/header/HeaderSearch.tsx
@@ -1,22 +1,27 @@
 'use client';
 
-import {useState} from 'react';
+import {useState, useEffect, Suspense} from 'react';
 import {MagnifyingGlassIcon} from "@heroicons/react/24/outline";
-import {useRouter} from "next/navigation";
+import {useRouter, useSearchParams} from "next/navigation";
 
 type Props = {
     isNarrow: boolean;
 };
 
-export default function HeaderSearch({ isNarrow }: Props) {
+function SearchInput({ isNarrow }: Props) {
     const [search, setSearch] = useState('');
     const [isComposing, setIsComposing] = useState(false);
     const router = useRouter();
+    const searchParams = useSearchParams();
+
+    useEffect(() => {
+        const queryFromUrl = searchParams.get('q') || '';
+        setSearch(queryFromUrl);
+    }, [searchParams]);
 
     const handleSearch = () => {
         if (!search.trim()) return;
         router.push(`/search?q=${encodeURIComponent(search)}`);
-        setSearch('');
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -58,5 +63,49 @@ export default function HeaderSearch({ isNarrow }: Props) {
                 <MagnifyingGlassIcon className="size-5 text-gray-400 stroke-2"/>
             </button>
         </div>
+    );
+}
+
+function SearchInputFallback({ isNarrow }: Props) {
+    return (
+        <div
+            className={`${
+                isNarrow
+                    ? 'inline-flex w-auto'
+                    : 'flex w-full ml-10 max-w-2xl'
+            } items-center border border-gray-300 rounded-full`}
+        >
+            <input
+                type="text"
+                disabled
+                value=""
+                placeholder={
+                    isNarrow
+                        ? "검색어나 링크를 넣어보세요."
+                        : "영상과 채널을 검색하거나 링크를 넣어보세요."
+                }
+                className={`text-gray-700 text-sm focus:outline-none rounded-l-full hover:bg-gray-100 transition-colors duration-200
+          ${
+                    isNarrow
+                        ? 'flex-none w-52 pl-3 pr-2 py-2'
+                        : 'flex-1 pl-4 pr-3 py-2'
+                }`}
+            />
+            <button
+                type="button"
+                disabled
+                className="pl-3 pr-4 py-2 hover:bg-gray-100 transition-colors duration-200 rounded-r-full"
+            >
+                <MagnifyingGlassIcon className="size-5 text-gray-400 stroke-2"/>
+            </button>
+        </div>
+    );
+}
+
+export default function HeaderSearch({ isNarrow }: Props) {
+    return (
+        <Suspense fallback={<SearchInputFallback isNarrow={isNarrow} />}>
+            <SearchInput isNarrow={isNarrow} />
+        </Suspense>
     );
 }

--- a/src/components/search/index.tsx
+++ b/src/components/search/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import {useSearchParams} from "next/navigation";
+import {useSearchParams, useRouter} from "next/navigation";
+import {useEffect} from "react";
 import SearchTabs from "@components/search/tabs/SearchTabs";
 import AllTab from "@components/search/tabs/AllTab";
 import VideoTab from "@components/search/tabs/VideoTab";
@@ -8,13 +9,24 @@ import ShortsTab from "@components/search/tabs/ShortsTab";
 import ChannelTab from "@components/search/tabs/ChannelTab";
 import CompareActions from "@components/search/CompareActions";
 import {useSearchQuery} from "@/hooks/useSearchQuery";
+import {extractYoutubeVideoId} from "@/utils/youtube";
 
 type TabType = 'all' | 'video' | 'shorts' | 'channel';
 
 export default function SearchContent() {
+    const router = useRouter();
     const searchParams = useSearchParams();
     const query = searchParams.get("q");
     const activeTab = (searchParams.get("tab") as TabType) || 'all';
+
+    useEffect(() => {
+        if (!query) return;
+
+        const videoId = extractYoutubeVideoId(query);
+        if (videoId) {
+            router.replace(`/videos/${videoId}`);
+        }
+    }, [query, router]);
 
     const {
         channels,

--- a/src/utils/youtube.ts
+++ b/src/utils/youtube.ts
@@ -1,0 +1,29 @@
+/**
+ * 유튜브 URL에서 videoId를 추출합니다.
+ *
+ * 지원 형식:
+ * - https://www.youtube.com/watch?v=VIDEO_ID
+ * - https://youtube.com/watch?v=VIDEO_ID
+ * - https://youtu.be/VIDEO_ID
+ * - https://m.youtube.com/watch?v=VIDEO_ID
+ * - https://www.youtube.com/embed/VIDEO_ID
+ * - https://www.youtube.com/v/VIDEO_ID
+ *
+ * @param url 유튜브 URL 또는 일반 문자열
+ * @returns videoId (11자리) 또는 null
+ */
+export function extractYoutubeVideoId(url: string): string | null {
+    if (!url) {
+        return null;
+    }
+
+    const VIDEO_ID_PATTERN = /(?:youtube\.com\/(?:watch\?v=|embed\/|v\/)|youtu\.be\/|m\.youtube\.com\/watch\?v=)([\w-]{11})/;
+
+    const match = url.match(VIDEO_ID_PATTERN);
+
+    if (match && match[1]) {
+        return match[1];
+    }
+
+    return null;
+}


### PR DESCRIPTION
<!-- 이슈 번호를 매겨주세요 -->
- resolves #95 
---
### 🚀 어떤 기능을 구현했나요?
- 검색창에 유튜브 URL 입력 시 영상 상세 페이지로 자동 리다이렉트
- 검색어 URL 쿼리와 동기화

### 🔥 어떻게 해결했나요?
- `utils/youtube.ts` 추가: videoId 추출 로직
- SearchContent에 URL 감지 후 `/videos/{videoId}` 리다이렉트
- HeaderSearch에 Suspense 추가 및 검색어 상태 URL과 동기화

### 📝 어떤 부분에 집중해서 리뷰해야 할까요?
- 유튜브 URL 패턴 정규식 정확성
- SearchContent의 리다이렉트 타이밍

### 📚 참고 자료, 할 말
- 지원 URL 형식: youtube.com/watch, youtu.be, m.youtube.com, embed, v